### PR TITLE
lru cache (map+list)

### DIFF
--- a/cache/lru.go
+++ b/cache/lru.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"container/list"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type Cache struct {
+	capacity  int
+	cacheMap  map[interface{}]*list.Element
+	cacheList *list.List
+	mu        sync.Mutex
+}
+
+type lruItem struct {
+	key   string
+	value []byte
+}
+
+func NewCache(capacity int) *Cache {
+	return &Cache{
+		capacity:  capacity,
+		cacheMap:  make(map[interface{}]*list.Element),
+		cacheList: list.New(),
+	}
+}
+
+func (c *Cache) Get(key []byte) ([]byte, bool) {
+	keyStr := convert(key)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.get(keyStr)
+}
+
+func (c *Cache) Set(key, value []byte) {
+	keyStr := convert(key)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.set(keyStr, value)
+}
+
+func (c *Cache) get(key interface{}) ([]byte, bool) {
+	ele, ok := c.cacheMap[key]
+	if ok {
+		c.cacheList.MoveToFront(ele)
+		item := ele.Value.(*lruItem)
+		return item.value, true
+	}
+	return nil, false
+}
+
+func (c *Cache) set(key string, value []byte) {
+	ele, ok := c.cacheMap[key]
+	if ok {
+		item := c.cacheMap[key].Value.(*lruItem)
+		item.value = value
+		c.cacheList.MoveToFront(ele)
+	} else {
+		ele = c.cacheList.PushFront(&lruItem{key: key, value: value})
+		c.cacheMap[key] = ele
+
+		if c.cacheList.Len() > c.capacity {
+			c.removeOldest()
+		}
+	}
+}
+
+func (c *Cache) removeOldest() {
+	ele := c.cacheList.Back()
+	c.cacheList.Remove(ele)
+	item := ele.Value.(*lruItem)
+	delete(c.cacheMap, item.key)
+}
+
+func convert(bytes []byte) string {
+	var str strings.Builder
+	for _, b := range bytes {
+		str.WriteString(fmt.Sprintf("%d,", int(b)))
+	}
+	return str.String()[:str.Len()-1]
+}

--- a/config.go
+++ b/config.go
@@ -43,6 +43,9 @@ const (
 	// DefaultMergeCheckInterval a timer will be set according to the check interval.
 	// Then merge operation will execute periodically.
 	DefaultMergeCheckInterval = time.Hour * 24
+
+	// DefaultCacheCapacity default cache capacity: 64.
+	DefaultCacheCapacity = 64
 )
 
 // Config the opening options of rosedb.
@@ -67,6 +70,7 @@ type Config struct {
 	MergeThreshold int `json:"merge_threshold" toml:"merge_threshold"` // threshold to reclaim disk
 
 	MergeCheckInterval time.Duration `json:"merge_check_interval"`
+	CacheCapacity      int           `json:"cache_capacity" toml:"cache_capacity"`
 }
 
 // DefaultConfig get the default config.
@@ -82,5 +86,6 @@ func DefaultConfig() Config {
 		Sync:               false,
 		MergeThreshold:     DefaultMergeThreshold,
 		MergeCheckInterval: DefaultMergeCheckInterval,
+		CacheCapacity:      DefaultCacheCapacity,
 	}
 }

--- a/config.toml
+++ b/config.toml
@@ -34,3 +34,7 @@ sync = false
 # reclaim的阈值
 # The threshold for db file reclaiming.
 merge_threshold = 64
+
+# cache容量
+# The capacity of cache
+cache_capacity = 64

--- a/db_str_test.go
+++ b/db_str_test.go
@@ -435,3 +435,23 @@ func BenchmarkRoseDB_Get(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkRoseDB_CacheGet(b *testing.B) {
+	for i := 0; i < 50; i++ {
+		roseDB.Set(GetKey(i), GetValue())
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 50; j++ {
+			var res interface{}
+			err := roseDB.Get(GetKey(j), &res)
+			if err != nil && err != ErrKeyNotExist {
+				panic(err)
+			}
+		}
+	}
+	// noCache BenchmarkRoseDB_CacheGet-6   	    6424	    191100 ns/op	   18837 B/op	     500 allocs/op
+	// map 	   BenchmarkRoseDB_CacheGet-6   	    7688	    162494 ns/op	   15241 B/op	    1350 allocs/op
+}

--- a/rosedb.go
+++ b/rosedb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/roseduan/rosedb/cache"
 	"io"
 	"log"
 	"os"
@@ -100,6 +101,7 @@ type (
 		txnMeta         *TxnMeta      // Txn meta info used in transaction.
 		closed          uint32
 		mergeChn        chan struct{} // mergeChn used for sending stop signal to merge func.
+		cache           *cache.Cache  // lru cache for db_str.
 	}
 
 	// ArchivedFiles define the archived files, which mean these files can only be read.
@@ -152,6 +154,7 @@ func Open(config Config) (*RoseDB, error) {
 		zsetIndex:  newZsetIdx(),
 		expires:    make(Expires),
 		txnMeta:    txnMeta,
+		cache:      cache.NewCache(config.CacheCapacity),
 	}
 	for i := 0; i < DataStructureNum; i++ {
 		db.expires[uint16(i)] = make(map[string]int64)


### PR DESCRIPTION
cache还是map+双端列表的结构，若只使用一个双端列表，在遍历列表时，得把每个元素取出来类型转换后再一一对比，不太行。
遇到的问题是如果将[]byte作为map的key，没有想到很好的办法，用了个笨办法，把[]byte元素遍历取出来，然后拼接成一个string。测试了下，适用于lru的场景下，效率有提升，但没有想象中的显著。可能使用磁盘，os也使用了页缓存。