### PR TITLE
mmap bug fix

### DIFF
--- a/storage/db_file.go
+++ b/storage/db_file.go
@@ -3,13 +3,14 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"github.com/roseduan/mmap-go"
 	"hash/crc32"
 	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/roseduan/mmap-go"
 )
 
 const (
@@ -39,6 +40,8 @@ var (
 var (
 	// ErrEmptyEntry the entry is empty.
 	ErrEmptyEntry = errors.New("storage/db_file: entry or the Key of entry is empty")
+	// ErrEmptyEntry the entry is empty.
+	ErrEntryTooLarge = errors.New("storage/db_file: entry is too large to store in mmap mode")
 )
 
 // FileRWMethod db file read and write method.
@@ -180,6 +183,9 @@ func (df *DBFile) Write(e *Entry) error {
 		}
 	}
 	if method == MMap {
+		if writeOff+int64(len(encVal)) > int64(len(df.mmap)) {
+			return ErrEntryTooLarge
+		}
 		copy(df.mmap[writeOff:], encVal)
 	}
 	df.Offset += int64(e.Size())

--- a/storage/db_file_test.go
+++ b/storage/db_file_test.go
@@ -44,7 +44,37 @@ func TestNewDBFile(t *testing.T) {
 		}
 	})
 }
-
+func TestMMapWrite(t *testing.T) {
+	var pathMMptest = "/tmp/rosedb-mmap/"
+	os.MkdirAll(pathMMptest, os.ModePerm)
+	entry := NewEntryNoExtra(make([]byte, 11), make([]byte, 10), String, 0)
+	var maxEntrySize int64 = entryHeaderSize + 20
+	t.Run("new db file mmap", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			fd, err := NewDBFile(pathMMptest, 0, MMap, maxEntrySize, uint16(i))
+			if err != nil {
+				t.Error("new db file error ", err)
+			}
+			err = fd.Write(entry)
+			if err != ErrEntryTooLarge {
+				t.Error("entry write should be ErrEntryTooLarge")
+			}
+		}
+	})
+	entry2 := NewEntryNoExtra(make([]byte, 10), make([]byte, 10), String, 0)
+	t.Run("new db file mmap", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			fd, err := NewDBFile(pathMMptest, 1, MMap, maxEntrySize, uint16(i))
+			if err != nil {
+				t.Error("new db file error ", err)
+			}
+			err = fd.Write(entry2)
+			if err != nil {
+				t.Error("entry write should be success")
+			}
+		}
+	})
+}
 func TestDBFile_Sync(t *testing.T) {
 	df, err := NewDBFile(path1, fileID1, FileIO, defaultBlockSize, 1)
 	if err != nil {


### PR DESCRIPTION
Write with `mmap`  is not safe, we should be careful about the data size otherwise the data will be lost.