### PR TITLE
优化Open函数加载索引方式，变更store函数中切换文件处理方式

### DIFF
--- a/storage/db_file_test.go
+++ b/storage/db_file_test.go
@@ -141,6 +141,22 @@ func TestDBFile_Write(t *testing.T) {
 	writeEntry([]byte("mmap_key_002"), []byte("mmap_val_002"))
 }
 
+func TestDBFile_ReadAll(t *testing.T) {
+	archFiles, _, err :=  Build("/tmp/rosedb_server", FileIO, 16 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	for _, file := range archFiles {
+		entries, err := file.ReadAll()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if len(entries) != 3 {
+			t.Fatal("want 3 entries, got ", len(entries))
+		}
+	}
+}
+
 func TestDBFile_Read(t *testing.T) {
 	//readEntry := func(offset int64) {
 	//	if e, err := df.Read(offset); err != nil {


### PR DESCRIPTION
# Open中索引加载方式
## 目前实现
对于一个存档file， 基于config的BlockSize分批次读取文件中的entry
## 可能存在的问题
如果当前用户指定了新的config，而且新配置的BlockSize(NewBlockSize)和存档file生成时的BlockSize(GenBlockSize)不同：
* NewBlockSize < GenBlockSize: 将会导致该存档文件NewBlockSize偏移处开始的数据无法加载到索引中
* NewBlockSize < GenBlockSize: 触发EOF
## 解决方法
修改之前分批读取方式, 一次性将文件读取到buff中，不根据配置中的BlockSize分批次读取。同时也能有效减少io次数

# 变更store函数中切换文件处理方式
## 目前处理方式
先判断当前entry是否能够放到文件中，如果不能则切换新文件；然后再执行write
## 可能的问题
会存在空间浪费，尤其对于一个较大的entry而言，可能当前文件仅仅比大entry小一点，但是剩余的空间无法使用
## 解决方法
类似MySQL binlog对于事务的处理方式，当事务大小超过binlog file限制时，允许扩大binlog file以容纳最后一个事务binlog。从而节省空间