### PR TITLE
feat: del expired kv of string type

### DIFF
--- a/db.go
+++ b/db.go
@@ -3,12 +3,6 @@ package rosedb
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/flower-corp/rosedb/ds/art"
-	"github.com/flower-corp/rosedb/ds/zset"
-	"github.com/flower-corp/rosedb/flock"
-	"github.com/flower-corp/rosedb/logfile"
-	"github.com/flower-corp/rosedb/logger"
-	"github.com/flower-corp/rosedb/util"
 	"io"
 	"io/ioutil"
 	"math"
@@ -22,6 +16,13 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/flower-corp/rosedb/ds/art"
+	"github.com/flower-corp/rosedb/ds/zset"
+	"github.com/flower-corp/rosedb/flock"
+	"github.com/flower-corp/rosedb/logfile"
+	"github.com/flower-corp/rosedb/logger"
+	"github.com/flower-corp/rosedb/util"
 )
 
 var (

--- a/strs.go
+++ b/strs.go
@@ -36,6 +36,7 @@ func (db *RoseDB) Get(key []byte) ([]byte, error) {
 	db.strIndex.mu.RLock()
 	idxNode, err := db.getIndexNode(db.strIndex.idxTree, key)
 	if err != nil {
+		db.strIndex.mu.RUnlock()
 		return nil, err
 	}
 

--- a/strs.go
+++ b/strs.go
@@ -170,19 +170,19 @@ func (db *RoseDB) Delete(key []byte) error {
 }
 
 func (db *RoseDB) deleteByIndexNode(key []byte, idxNode *indexNode) error {
-	// consider the case of concurrent write operations，so check if indexNode has changed
-	curIdxNode, err := db.getIndexNode(db.strIndex.idxTree, key)
+	// consider the case of concurrent write the same as key，so check if indexNode has changed
+	currentIdxNode, err := db.getIndexNode(db.strIndex.idxTree, key)
 	if err != nil {
 		return err
 	}
 
 	// the key is already deleted
-	if curIdxNode == nil {
+	if currentIdxNode == nil {
 		return nil
 	}
 
 	// changed
-	if curIdxNode.fid != idxNode.fid || curIdxNode.offset != curIdxNode.offset {
+	if currentIdxNode.fid != idxNode.fid || currentIdxNode.offset != currentIdxNode.offset {
 		return nil
 	}
 

--- a/strs_test.go
+++ b/strs_test.go
@@ -610,27 +610,20 @@ func testRoseDBSetEx(t *testing.T, mode DataIndexMode) {
 	assert.Nil(t, err)
 	defer destroyDB(db)
 
-	err = db.SetEX(GetKey(1), GetValue16B(), time.Millisecond*200)
+	err = db.SetEX(GetKey(1), GetValue16B(), time.Second)
 	assert.Nil(t, err)
-	time.Sleep(time.Millisecond * 205)
+	time.Sleep(2 * time.Second)
 	v, err := db.Get(GetKey(1))
 	assert.Equal(t, 0, len(v))
 	assert.Equal(t, ErrKeyNotFound, err)
-
-	err = db.SetEX(GetKey(2), GetValue16B(), time.Second*200)
-	assert.Nil(t, err)
-	time.Sleep(time.Millisecond * 200)
-	v1, err := db.Get(GetKey(2))
-	assert.NotNil(t, v1)
-	assert.Nil(t, err)
 
 	// set an existed key.
 	err = db.Set(GetKey(3), GetValue16B())
 	assert.Nil(t, err)
 
-	err = db.SetEX(GetKey(3), GetValue16B(), time.Millisecond*200)
+	err = db.SetEX(GetKey(3), GetValue16B(), time.Second)
 	assert.Nil(t, err)
-	time.Sleep(time.Millisecond * 205)
+	time.Sleep(2 * time.Second)
 	v2, err := db.Get(GetKey(3))
 	assert.Equal(t, 0, len(v2))
 	assert.Equal(t, ErrKeyNotFound, err)

--- a/strs_test.go
+++ b/strs_test.go
@@ -1722,7 +1722,7 @@ func testRoseDBExpire(t *testing.T, ioType IOType, mode DataIndexMode) {
 		err = db.Expire(GetKey(55), time.Second*1)
 		assert.Nil(t, err)
 
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		_, err = db.Get(GetKey(55))
 		assert.Equal(t, ErrKeyNotFound, err)
 	})
@@ -1733,7 +1733,7 @@ func testRoseDBExpire(t *testing.T, ioType IOType, mode DataIndexMode) {
 
 		db.Expire(GetKey(66), time.Second*100)
 		db.Expire(GetKey(66), time.Second*1)
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		_, err = db.Get(GetKey(66))
 		assert.Equal(t, ErrKeyNotFound, err)
 	})


### PR DESCRIPTION
## fix

当某个 kv 已经过期了，rosedb 在 get 时，只是返回错误 `keynotfound`，没有在索引中删除个key，也没有写 delete log。

只能等待该 key 对应的 logfile 的 discard 超阈值后，在进行 compact gc 时进行过滤。

### adjust

1. 判断过期从 `<= 小于等于` 改为 `< 小于`，跟 redis 对齐。 https://github.com/redis/redis/blob/1222b6087385aa431a412a9e9b59cf29ce55210e/src/db.c#L1649

2. Get() 查询时，如果key已经过期，再加写锁进行同步的删除。跟 redis 类似，属于被动过期处理。

3. 由于 rosedb 的 expire 单位是秒级，setex 单元测试的时间是 ms，ut 写的有问题。




