### PR TITLE
feat: discard batch safely after commit batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -27,7 +27,6 @@ type Batch struct {
 	mu            sync.RWMutex
 	committed     bool
 	rollbacked    bool
-	locked        bool
 	batchId       *snowflake.Node
 }
 
@@ -57,23 +56,14 @@ func (b *Batch) lock() {
 	} else {
 		b.db.mu.Lock()
 	}
-
-	b.locked = true
 }
 
 func (b *Batch) unlock() {
-	// if the lock has been released, return.
-	if !b.locked {
-		return
-	}
-
 	if b.options.ReadOnly {
 		b.db.mu.RUnlock()
 	} else {
 		b.db.mu.Unlock()
 	}
-
-	b.locked = false
 }
 
 // Put adds a key-value pair to the batch for writing.

--- a/batch_test.go
+++ b/batch_test.go
@@ -177,7 +177,7 @@ func assertKeyExistOrNot(t *testing.T, db *DB, key []byte, exist bool) {
 	}
 }
 
-func TestBatch_Multi_Commit(t *testing.T) {
+func TestBatch_Rollback(t *testing.T) {
 	options := DefaultOptions
 	db, err := Open(options)
 	assert.Nil(t, err)
@@ -190,60 +190,10 @@ func TestBatch_Multi_Commit(t *testing.T) {
 	err = batcher.Put(key, value)
 	assert.Nil(t, err)
 
-	batcher.Commit()
-
-	// invalid call
-	batcher.Commit()
+	err = batcher.Rollback()
+	assert.Nil(t, err)
 
 	resp, err := db.Get(key)
-	assert.Nil(t, err)
-	assert.EqualValues(t, value, resp)
-}
-
-func TestBatch_Discard_Rollback(t *testing.T) {
-	options := DefaultOptions
-	db, err := Open(options)
-	assert.Nil(t, err)
-	defer destroyDB(db)
-
-	key := []byte("rosedb")
-	value := []byte("val")
-
-	batcher := db.NewBatch(DefaultBatchOptions)
-	err = batcher.Put(key, value)
-	assert.Nil(t, err)
-
-	batcher.Rollback()
-
-	// invalid call
-	batcher.Rollback()
-	batcher.Commit()
-	batcher.Commit()
-
-	_, err = db.Get(key)
 	assert.Equal(t, ErrKeyNotFound, err)
-}
-
-func TestBatch_Commit_Rollback(t *testing.T) {
-	options := DefaultOptions
-	db, err := Open(options)
-	assert.Nil(t, err)
-	defer destroyDB(db)
-
-	key := []byte("rosedb")
-	value := []byte("val")
-
-	batcher := db.NewBatch(DefaultBatchOptions)
-	err = batcher.Put(key, value)
-	assert.Nil(t, err)
-
-	batcher.Commit()
-
-	// invalid call
-	batcher.Rollback()
-	batcher.Commit()
-
-	resp, err := db.Get(key)
-	assert.Equal(t, nil, err)
-	assert.EqualValues(t, resp, value)
+	assert.Empty(t, resp)
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -200,7 +200,7 @@ func TestBatch_Multi_Commit(t *testing.T) {
 	assert.EqualValues(t, value, resp)
 }
 
-func TestBatch_Discard_Commit(t *testing.T) {
+func TestBatch_Discard_Rollback(t *testing.T) {
 	options := DefaultOptions
 	db, err := Open(options)
 	assert.Nil(t, err)
@@ -213,10 +213,10 @@ func TestBatch_Discard_Commit(t *testing.T) {
 	err = batcher.Put(key, value)
 	assert.Nil(t, err)
 
-	batcher.Discard()
+	batcher.Rollback()
 
 	// invalid call
-	batcher.Discard()
+	batcher.Rollback()
 	batcher.Commit()
 	batcher.Commit()
 
@@ -224,7 +224,7 @@ func TestBatch_Discard_Commit(t *testing.T) {
 	assert.Equal(t, ErrKeyNotFound, err)
 }
 
-func TestBatch_Commit_Discard(t *testing.T) {
+func TestBatch_Commit_Rollback(t *testing.T) {
 	options := DefaultOptions
 	db, err := Open(options)
 	assert.Nil(t, err)
@@ -240,7 +240,7 @@ func TestBatch_Commit_Discard(t *testing.T) {
 	batcher.Commit()
 
 	// invalid call
-	batcher.Discard()
+	batcher.Rollback()
 	batcher.Commit()
 
 	resp, err := db.Get(key)

--- a/batch_test.go
+++ b/batch_test.go
@@ -192,7 +192,7 @@ func TestBatch_Multi_Commit(t *testing.T) {
 
 	batcher.Commit()
 
-	// invalid discard
+	// invalid call
 	batcher.Commit()
 
 	resp, err := db.Get(key)
@@ -200,7 +200,7 @@ func TestBatch_Multi_Commit(t *testing.T) {
 	assert.EqualValues(t, value, resp)
 }
 
-func TestBatch_Discard1(t *testing.T) {
+func TestBatch_Discard_Commit(t *testing.T) {
 	options := DefaultOptions
 	db, err := Open(options)
 	assert.Nil(t, err)
@@ -215,10 +215,8 @@ func TestBatch_Discard1(t *testing.T) {
 
 	batcher.Discard()
 
-	// invalid discard
+	// invalid call
 	batcher.Discard()
-
-	// invalid commit
 	batcher.Commit()
 	batcher.Commit()
 
@@ -226,7 +224,7 @@ func TestBatch_Discard1(t *testing.T) {
 	assert.Equal(t, ErrKeyNotFound, err)
 }
 
-func TestBatch_Discard2(t *testing.T) {
+func TestBatch_Commit_Discard(t *testing.T) {
 	options := DefaultOptions
 	db, err := Open(options)
 	assert.Nil(t, err)
@@ -241,10 +239,8 @@ func TestBatch_Discard2(t *testing.T) {
 
 	batcher.Commit()
 
-	// invalid discard
+	// invalid call
 	batcher.Discard()
-
-	// invalid commit
 	batcher.Commit()
 
 	resp, err := db.Get(key)

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,6 @@ var (
 	ErrDatabaseIsUsing = errors.New("the database directory is used by another process")
 	ErrReadOnlyBatch   = errors.New("the batch is read only")
 	ErrBatchCommitted  = errors.New("the batch is committed")
-	ErrBatchDiscarded  = errors.New("the batch is discarded")
+	ErrBatchRollbacked = errors.New("the batch is rollbacked")
 	ErrDBClosed        = errors.New("the database is closed")
 )

--- a/errors.go
+++ b/errors.go
@@ -8,5 +8,6 @@ var (
 	ErrDatabaseIsUsing = errors.New("the database directory is used by another process")
 	ErrReadOnlyBatch   = errors.New("the batch is read only")
 	ErrBatchCommitted  = errors.New("the batch is committed")
+	ErrBatchDiscarded  = errors.New("the batch is discarded")
 	ErrDBClosed        = errors.New("the database is closed")
 )

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	// create a batch
 	batch := db.NewBatch(rosedb.DefaultBatchOptions)
-	defer batch.Discard()
+	defer batch.Rollback()
 
 	// set a key
 	_ = batch.Put([]byte("name"), []byte("rosedb"))

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/rosedblabs/rosedb/v2"
+import (
+	"github.com/rosedblabs/rosedb/v2"
+)
 
 // this file shows how to use the batch operations of rosedb
 
@@ -20,6 +22,7 @@ func main() {
 
 	// create a batch
 	batch := db.NewBatch(rosedb.DefaultBatchOptions)
+	defer batch.Discard()
 
 	// set a key
 	_ = batch.Put([]byte("name"), []byte("rosedb"))

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -22,7 +22,6 @@ func main() {
 
 	// create a batch
 	batch := db.NewBatch(rosedb.DefaultBatchOptions)
-	defer batch.Rollback()
 
 	// set a key
 	_ = batch.Put([]byte("name"), []byte("rosedb"))
@@ -36,6 +35,9 @@ func main() {
 
 	// commit the batch
 	_ = batch.Commit()
+
+	// if you want to cancel batch, you must call rollback().
+	// _= batch.Rollback()
 
 	// once a batch is committed, it can't be used again
 	// _ = batch.Put([]byte("name1"), []byte("rosedb1")) // don't do this!!!


### PR DESCRIPTION
## change

1. discard batch safely.
2. lock/unlock safely.

#### refer:

- [https://pkg.go.dev/github.com/dgraph-io/badger#Txn.Discard](https://pkg.go.dev/github.com/dgraph-io/badger#Txn.Discard)
- [https://pkg.go.dev/github.com/dgraph-io/badger#WriteBatch.Cancel](https://pkg.go.dev/github.com/dgraph-io/badger#WriteBatch.Cancel)