### PR TITLE
refactor event watch

### DIFF
--- a/db.go
+++ b/db.go
@@ -117,6 +117,8 @@ func Open(options Options) (*DB, error) {
 	// enable watch
 	if options.WatchQueueSize > 0 {
 		db.watcher = newWatcher(options.WatchQueueSize)
+		// run a goroutine to synchronize event information
+		go db.watcher.sendEvent()
 	}
 
 	return db, nil

--- a/watch_test.go
+++ b/watch_test.go
@@ -13,7 +13,7 @@ func TestWatch_Insert_Scan(t *testing.T) {
 	// There are two spaces to determine whether the queue is full and overwrite the write.
 	size := capacity - 2
 	q := make([][2][]byte, 0, size)
-	w := newWatcher(uint64(capacity), true)
+	w := newWatcher(uint64(capacity))
 	for i := 0; i < size; i++ {
 		key := utils.GetTestKey(rand.Int())
 		value := utils.RandomValue(128)
@@ -39,7 +39,7 @@ func TestWatch_Insert_Scan(t *testing.T) {
 func TestWatch_Rotate_Insert_Scan(t *testing.T) {
 	capacity := 1000
 	q := make([][2][]byte, capacity)
-	w := newWatcher(uint64(capacity), true)
+	w := newWatcher(uint64(capacity))
 	for i := 0; i < 2500; i++ {
 		key := utils.GetTestKey(rand.Int())
 		value := utils.RandomValue(128)


### PR DESCRIPTION
1. potential panic: send on closed channel
2. using wait group to wait for goroutine in example
3. refactor event watch

fix: https://github.com/rosedblabs/rosedb/issues/283

Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>