### PR TITLE
replace original file and rebuilt index after merge

### DIFF
--- a/db.go
+++ b/db.go
@@ -102,10 +102,8 @@ func Open(options Options) (*DB, error) {
 	}
 
 	// open data files
-	if walFiles, err := db.openWalFiles(); err != nil {
+	if db.dataFiles, err = db.openWalFiles(); err != nil {
 		return nil, err
-	} else {
-		db.dataFiles = walFiles
 	}
 
 	// load index

--- a/examples/merge/main.go
+++ b/examples/merge/main.go
@@ -34,5 +34,5 @@ func main() {
 
 	// then merge the data files
 	// all the invalid data will be removed, and the valid data will be merged into the new data files.
-	_ = db.Merge()
+	_ = db.Merge(true)
 }

--- a/merge.go
+++ b/merge.go
@@ -41,19 +41,18 @@ func (db *DB) Merge(reopenAfterDone bool) error {
 	db.closeFiles()
 
 	// replace original file
-	if err := loadMergeFiles(db.options.DirPath); err != nil {
+	err := loadMergeFiles(db.options.DirPath)
+	if err != nil {
 		return err
 	}
 
 	// open data files
-	if walFiles, err := db.openWalFiles(); err != nil {
+	if db.dataFiles, err = db.openWalFiles(); err != nil {
 		return err
-	} else {
-		db.dataFiles = walFiles
 	}
 
 	// rebuild index
-	if err := db.loadIndex(); err != nil {
+	if err = db.loadIndex(); err != nil {
 		return err
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -24,10 +24,8 @@ const (
 //
 // Merge operation maybe a very time-consuming operation when the database is large.
 // So it is recommended to perform this operation when the database is idle.
-//
-// @param: reopenAfterDone
-// 	If true, the original file will be replaced by the merge file,
-// 	and db's index will be rebuilt after the merge is complete.
+// If reopenAfterDone is true, the original file will be replaced by the merge file,
+// and db's index will be rebuilt after the merge is complete.
 func (db *DB) Merge(reopenAfterDone bool) error {
 	db.mu.Lock()
 	// check if the database is closed

--- a/merge.go
+++ b/merge.go
@@ -27,7 +27,7 @@ const (
 // If reopenAfterDone is true, the original file will be replaced by the merge file,
 // and db's index will be rebuilt after the merge is complete.
 func (db *DB) Merge(reopenAfterDone bool) error {
-	if err := db.merge(); err != nil {
+	if err := db.doMerge(); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func (db *DB) Merge(reopenAfterDone bool) error {
 	return nil
 }
 
-func (db *DB) merge() error {
+func (db *DB) doMerge() error {
 	db.mu.Lock()
 	// check if the database is closed
 	if db.closed {

--- a/merge_test.go
+++ b/merge_test.go
@@ -240,7 +240,7 @@ func TestDB_Merge_ReopenAfterDone(t *testing.T) {
 	defer destroyDB(db)
 
 	kvs := make(map[string][]byte)
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 200000; i++ {
 		key := utils.GetTestKey(i)
 		value := utils.RandomValue(128)
 		kvs[string(key)] = value

--- a/merge_test.go
+++ b/merge_test.go
@@ -15,7 +15,7 @@ func TestDB_Merge_1_Empty(t *testing.T) {
 	assert.Nil(t, err)
 	defer destroyDB(db)
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 }
 
@@ -34,7 +34,7 @@ func TestDB_Merge_2_All_Invalid(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 
 	_ = db.Close()
@@ -59,7 +59,7 @@ func TestDB_Merge_3_All_Valid(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 
 	_ = db.Close()
@@ -87,9 +87,9 @@ func TestDB_Merge_4_Twice(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 
 	_ = db.Close()
@@ -129,7 +129,7 @@ func TestDB_Merge_5_Mixed(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 
 	_ = db.Close()
@@ -180,7 +180,7 @@ func TestDB_Merge_6_Appending(t *testing.T) {
 		}()
 	}
 
-	err = db.Merge()
+	err = db.Merge(false)
 	assert.Nil(t, err)
 
 	wg.Wait()
@@ -215,7 +215,7 @@ func TestDB_Multi_Open_Merge(t *testing.T) {
 			assert.Nil(t, err)
 		}
 
-		err = db.Merge()
+		err = db.Merge(true)
 		assert.Nil(t, err)
 		err = db.Close()
 		assert.Nil(t, err)

--- a/merge_test.go
+++ b/merge_test.go
@@ -215,7 +215,7 @@ func TestDB_Multi_Open_Merge(t *testing.T) {
 			assert.Nil(t, err)
 		}
 
-		err = db.Merge(true)
+		err = db.Merge(false)
 		assert.Nil(t, err)
 		err = db.Close()
 		assert.Nil(t, err)


### PR DESCRIPTION
I have two ideas for this function:

1. After the merge is completed, replace the file and rebuild the index from disk.
Advantages: Memory usage does not increase.
Disadvantages: The whole process requires a write lock, and the db cannot be read or written externally.

2. Put the written index data into the temporary storage area during the merge process (like copy-on-write), and build an index while building the hint file. When the merge ends, the index of the temporary storage area and the hint index to combine.
Advantages: DB's write lock time is smooth and can be merged smoothly.
Disadvantage: There may be more than twice the memory overhead.

Based on the shortcomings of bitcase, I chose the first option.

