### PR TITLE
Delete expired key of the index

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -322,7 +322,7 @@ func (b *Batch) Commit() error {
 
 	// write to index
 	for key, record := range b.pendingWrites {
-		if record.Type == LogRecordDeleted {
+		if record.Type == LogRecordDeleted || (record.Expire > 0 && record.Expire <= now) {
 			b.db.index.Delete(record.Key)
 		} else {
 			b.db.index.Put(record.Key, positions[key])

--- a/db.go
+++ b/db.go
@@ -419,7 +419,7 @@ func (db *DB) DescendLessOrEqual(key []byte, handleFn func(k []byte, v []byte) (
 func (db *DB) checkValue(chunk []byte) ([]byte, error) {
 	record := decodeLogRecord(chunk)
 	now := time.Now().UnixNano()
-	if record.Type == LogRecordDeleted || (record.Expire > 0 && record.Expire <= now) {
+	if record.Type == LogRecordDeleted || record.IsExpired(now) {
 		return nil, ErrKeyNotFound
 	}
 	return record.Value, nil
@@ -490,7 +490,7 @@ func (db *DB) loadIndexFromWAL() error {
 			db.index.Put(record.Key, position)
 		} else {
 			// expired records should not be indexed
-			if record.Expire > 0 && record.Expire <= now {
+			if record.IsExpired(now) {
 				continue
 			}
 			// put the record into the temporary indexRecords

--- a/db.go
+++ b/db.go
@@ -420,6 +420,7 @@ func (db *DB) checkValue(chunk []byte) ([]byte, error) {
 	record := decodeLogRecord(chunk)
 	now := time.Now().UnixNano()
 	if record.Type == LogRecordDeleted || record.IsExpired(now) {
+		db.index.Delete(record.Key)
 		return nil, ErrKeyNotFound
 	}
 	return record.Value, nil

--- a/record.go
+++ b/record.go
@@ -34,6 +34,13 @@ type LogRecord struct {
 	Expire  int64
 }
 
+func (lr LogRecord) IsExpired(now int64) bool {
+	if lr.Expire > 0 && lr.Expire <= now {
+		return true
+	}
+	return false
+}
+
 // IndexRecord is the index record of the key.
 // It contains the key, the record type and the position of the record in the wal.
 // Only used in start up to rebuild the index.

--- a/record.go
+++ b/record.go
@@ -34,7 +34,7 @@ type LogRecord struct {
 	Expire  int64
 }
 
-func (lr LogRecord) IsExpired(now int64) bool {
+func (lr *LogRecord) IsExpired(now int64) bool {
 	if lr.Expire > 0 && lr.Expire <= now {
 		return true
 	}


### PR DESCRIPTION
Deleting the expired key directly can save the memory of the index