### PR TITLE
Fix potential deadlock in merge.go

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -88,6 +88,7 @@ func (db *DB) doMerge() error {
 	// rotate the write-ahead log, create a new active segment file.
 	// so all the older segment files will be merged.
 	if err := db.dataFiles.OpenNewActiveSegment(); err != nil {
+		db.mu.Unlock()
 		return err
 	}
 


### PR DESCRIPTION
https://github.com/rosedblabs/rosedb/blob/d3926133c6b78b082d1d0fe3253c5304db22bd64/merge.go#L88-L92

It seems that the lock isn't released when the `OpenNewActiveSegment` function returns an error