### PR TITLE
clarify file error

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -289,7 +289,10 @@ func loadMergeFiles(dirPath string) error {
 	mergeDirPath := mergeDirPath(dirPath)
 	if _, err := os.Stat(mergeDirPath); err != nil {
 		// does not exist, just return.
-		return nil
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
 	}
 
 	// remove the merge directory at last


### PR DESCRIPTION
加载合并目录的时候，错误需要分类，只有在目录不存在的时候，才能被忽略。其他的错误情况需要抛出err