### PR TITLE
style: 🎨 Using 'rolled back' instead of 'rollback'

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@ var (
 	ErrDatabaseIsUsing = errors.New("the database directory is used by another process")
 	ErrReadOnlyBatch   = errors.New("the batch is read only")
 	ErrBatchCommitted  = errors.New("the batch is committed")
-	ErrBatchRollbacked = errors.New("the batch is rollbacked")
+	ErrBatchRolledBack = errors.New("the batch is rolled back")
 	ErrDBClosed        = errors.New("the database is closed")
 	ErrMergeRunning    = errors.New("the merge operation is running")
 	ErrWatchDisabled   = errors.New("the watch is disabled")


### PR DESCRIPTION
Using 'rolled back' instead of 'rollbacked' seems more appropriate.