### PR TITLE
fix: inner error bug in the delete expired key method.

### DIFF
--- a/db.go
+++ b/db.go
@@ -714,6 +714,6 @@ func (db *DB) DeleteExpiredKeys(timeout time.Duration) error {
 	case <-ctx.Done():
 		return innerErr
 	case <-done:
-		return nil
+		return innerErr
 	}
 }


### PR DESCRIPTION
see issue: [channel asynchronous time error problem #321
](https://github.com/rosedblabs/rosedb/issues/321)