### PR TITLE
fix typo error

### DIFF
--- a/db.go
+++ b/db.go
@@ -168,7 +168,7 @@ func (db *DB) openWalFiles() (*wal.WAL, error) {
 }
 
 func (db *DB) loadIndex() error {
-	// load index frm hint file
+	// load index from hint file
 	if err := db.loadIndexFromHintFile(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello, I found a typo error in the comments from the db.go. The revision is as follows: "frm" -> "from".