### PR TITLE
feat: add disk-based B+Tree index implementation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,17 +10,19 @@ jobs:
 
   ubuntu-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        index-type: [BTree, BPTree]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.21'
 
       - name: Run Go Vet
-        run: |
-          go vet ./...
+        run: go vet ./...
 
       - name: Run Go Fmt
         run: |
@@ -34,8 +36,15 @@ jobs:
       - name: Build
         run: go build -v
 
-      - name: Run Unit Test
-        run: go test -count 1 -v ./...
+      - name: Set Index Type to ${{ matrix.index-type }}
+        run: |
+          if [ "${{ matrix.index-type }}" == "BPTree" ]; then
+            sed -i 's/IndexType:.*index\.BTree/IndexType:         index.BPTree/' options.go
+          fi
+          grep "IndexType:" options.go
+
+      - name: Run Unit Test (${{ matrix.index-type }})
+        run: go test -race -count 1 -v ./...
 
       - name: Run Benchmark Test
         working-directory: ./benchmark
@@ -43,23 +52,33 @@ jobs:
 
   windows-test:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        index-type: [BTree, BPTree]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.21'
 
       - name: Run Go Vet
-        run: |
-          go vet ./...
+        run: go vet ./...
 
       - name: Build
         run: go build -v
 
-      - name: Run Unit Test
-        run: go test -count 1 -v ./...
+      - name: Set Index Type to ${{ matrix.index-type }}
+        shell: pwsh
+        run: |
+          if ("${{ matrix.index-type }}" -eq "BPTree") {
+            (Get-Content options.go) -replace 'IndexType:.*index\.BTree', 'IndexType:         index.BPTree' | Set-Content options.go
+          }
+          Select-String -Path options.go -Pattern "IndexType:"
+
+      - name: Run Unit Test (${{ matrix.index-type }})
+        run: go test -race -count 1 -v ./...
 
       - name: Run Benchmark Test
         working-directory: ./benchmark

--- a/index/bptree/bptree.go
+++ b/index/bptree/bptree.go
@@ -1,0 +1,554 @@
+package bptree
+
+import (
+	"bytes"
+	"os"
+	"sync"
+
+	"github.com/rosedblabs/wal"
+)
+
+// BPlusTree represents a disk-based B+Tree index.
+type BPlusTree struct {
+	file     *os.File
+	meta     *MetaPage
+	cache    *PageCache
+	freelist *FreeList
+	order    int
+	mu       sync.RWMutex
+	fileMu   sync.Mutex // protects file read/write operations
+	options  Options
+}
+
+// Open opens or creates a B+Tree index file.
+func Open(path string, options Options) (*BPlusTree, error) {
+	if options.PageSize == 0 {
+		options.PageSize = DefaultOptions.PageSize
+	}
+	if options.CacheSize == 0 {
+		options.CacheSize = DefaultOptions.CacheSize
+	}
+	if options.Order == 0 {
+		options.Order = calculateOrder(options.PageSize)
+	}
+
+	// Open or create file
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	tree := &BPlusTree{
+		file:     file,
+		freelist: NewFreeList(),
+		order:    options.Order,
+		options:  options,
+	}
+
+	// Create cache with flush callback
+	tree.cache = NewPageCache(options.CacheSize, options.PageSize, func(pageID uint32, data []byte) error {
+		return tree.writePage(pageID, data)
+	})
+
+	// Check if file is empty (new index)
+	stat, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+
+	if stat.Size() == 0 {
+		// Initialize new B+Tree
+		if err := tree.initialize(); err != nil {
+			file.Close()
+			return nil, err
+		}
+	} else {
+		// Load existing B+Tree
+		if err := tree.load(); err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
+
+	return tree, nil
+}
+
+// initialize creates a new B+Tree with empty root.
+func (t *BPlusTree) initialize() error {
+	// Create meta page
+	t.meta = &MetaPage{
+		Magic:        MagicNumber,
+		Version:      Version,
+		PageSize:     t.options.PageSize,
+		RootPageID:   1, // Root will be page 1
+		FreeListPage: 0, // No free list page initially
+		KeyCount:     0,
+		PageCount:    2, // Meta + Root
+	}
+
+	// Create empty root leaf node
+	root := &Node{
+		PageID:   1,
+		PageType: PageTypeLeaf,
+		KeyCount: 0,
+		Parent:   InvalidPageID,
+		Next:     InvalidPageID,
+		Prev:     InvalidPageID,
+		Keys:     make([][]byte, 0),
+		Values:   make([]*wal.ChunkPosition, 0),
+		dirty:    true,
+	}
+
+	// Write meta page
+	if err := t.writePage(0, t.meta.Serialize()); err != nil {
+		return err
+	}
+
+	// Write root page
+	if err := t.writePage(1, root.Serialize(t.options.PageSize)); err != nil {
+		return err
+	}
+
+	t.cache.Put(root)
+	return nil
+}
+
+// load loads an existing B+Tree from disk.
+func (t *BPlusTree) load() error {
+	// Read meta page
+	metaBuf := make([]byte, t.options.PageSize)
+	if _, err := t.file.ReadAt(metaBuf, 0); err != nil {
+		return err
+	}
+
+	meta, err := DeserializeMetaPage(metaBuf)
+	if err != nil {
+		return err
+	}
+	t.meta = meta
+	t.options.PageSize = meta.PageSize
+
+	// Load free list if exists
+	if meta.FreeListPage != InvalidPageID {
+		buf := make([]byte, t.options.PageSize)
+		if _, err := t.file.ReadAt(buf, int64(meta.FreeListPage)*int64(t.options.PageSize)); err != nil {
+			return err
+		}
+		t.freelist = DeserializeFreeList(buf)
+	}
+
+	return nil
+}
+
+// Close closes the B+Tree and flushes all dirty pages.
+func (t *BPlusTree) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Flush all dirty pages
+	if err := t.flush(); err != nil {
+		return err
+	}
+
+	return t.file.Close()
+}
+
+// flush writes all dirty pages to disk.
+func (t *BPlusTree) flush() error {
+	// Flush dirty pages
+	dirtyPages := t.cache.GetDirtyPages()
+	for _, pageID := range dirtyPages {
+		node := t.cache.Get(pageID)
+		if node != nil {
+			if err := t.writePage(pageID, node.Serialize(t.options.PageSize)); err != nil {
+				return err
+			}
+			t.cache.ClearDirty(pageID)
+		}
+	}
+
+	// Write meta page
+	if err := t.writePage(0, t.meta.Serialize()); err != nil {
+		return err
+	}
+
+	// Write free list if not empty
+	if t.freelist.Count() > 0 {
+		if t.meta.FreeListPage == InvalidPageID {
+			t.meta.FreeListPage = t.allocatePage()
+		}
+		if err := t.writePage(t.meta.FreeListPage, t.freelist.Serialize(t.options.PageSize)); err != nil {
+			return err
+		}
+	}
+
+	if t.options.SyncWrites {
+		return t.file.Sync()
+	}
+	return nil
+}
+
+// Sync flushes all dirty pages to disk.
+func (t *BPlusTree) Sync() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flush()
+}
+
+// readPage reads a page from disk.
+func (t *BPlusTree) readPage(pageID uint32) ([]byte, error) {
+	t.fileMu.Lock()
+	defer t.fileMu.Unlock()
+
+	buf := make([]byte, t.options.PageSize)
+	_, err := t.file.ReadAt(buf, int64(pageID)*int64(t.options.PageSize))
+	return buf, err
+}
+
+// writePage writes a page to disk.
+func (t *BPlusTree) writePage(pageID uint32, data []byte) error {
+	t.fileMu.Lock()
+	defer t.fileMu.Unlock()
+
+	// Ensure data is page-sized
+	if len(data) < int(t.options.PageSize) {
+		padded := make([]byte, t.options.PageSize)
+		copy(padded, data)
+		data = padded
+	}
+	_, err := t.file.WriteAt(data, int64(pageID)*int64(t.options.PageSize))
+	return err
+}
+
+// getNode retrieves a node, first checking cache, then disk.
+func (t *BPlusTree) getNode(pageID uint32) (*Node, error) {
+	// Check cache first
+	if node := t.cache.Get(pageID); node != nil {
+		return node, nil
+	}
+
+	// Read from disk
+	buf, err := t.readPage(pageID)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := DeserializeNode(pageID, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	t.cache.Put(node)
+	return node, nil
+}
+
+// allocatePage allocates a new page ID.
+func (t *BPlusTree) allocatePage() uint32 {
+	// Try free list first
+	if pageID := t.freelist.Allocate(); pageID != InvalidPageID {
+		return pageID
+	}
+
+	// Allocate new page
+	pageID := t.meta.PageCount
+	t.meta.PageCount++
+	return pageID
+}
+
+// Put inserts or updates a key-value pair.
+func (t *BPlusTree) Put(key []byte, pos *wal.ChunkPosition) *wal.ChunkPosition {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Find leaf node
+	leaf, err := t.findLeaf(key)
+	if err != nil {
+		return nil
+	}
+
+	// Try to find existing key
+	idx, found := t.searchInNode(leaf, key)
+
+	var oldPos *wal.ChunkPosition
+	if found {
+		// Update existing key
+		oldPos = leaf.Values[idx]
+		leaf.Values[idx] = pos
+	} else {
+		// Insert new key
+		t.insertIntoLeaf(leaf, idx, key, pos)
+		t.meta.KeyCount++
+	}
+
+	t.cache.MarkDirty(leaf.PageID)
+
+	// Check if node needs splitting
+	if int(leaf.KeyCount) >= t.order {
+		t.splitLeaf(leaf)
+	}
+
+	return oldPos
+}
+
+// Get retrieves the value for a key.
+func (t *BPlusTree) Get(key []byte) *wal.ChunkPosition {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	leaf, err := t.findLeaf(key)
+	if err != nil {
+		return nil
+	}
+
+	idx, found := t.searchInNode(leaf, key)
+	if !found {
+		return nil
+	}
+
+	return leaf.Values[idx]
+}
+
+// Delete removes a key from the tree.
+func (t *BPlusTree) Delete(key []byte) (*wal.ChunkPosition, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	leaf, err := t.findLeaf(key)
+	if err != nil {
+		return nil, false
+	}
+
+	idx, found := t.searchInNode(leaf, key)
+	if !found {
+		return nil, false
+	}
+
+	oldPos := leaf.Values[idx]
+
+	// Remove key-value from leaf
+	leaf.Keys = append(leaf.Keys[:idx], leaf.Keys[idx+1:]...)
+	leaf.Values = append(leaf.Values[:idx], leaf.Values[idx+1:]...)
+	leaf.KeyCount--
+	t.meta.KeyCount--
+
+	t.cache.MarkDirty(leaf.PageID)
+
+	// Note: For simplicity, we don't implement node merging here
+	// A full implementation would handle underflow by merging or redistributing
+
+	return oldPos, true
+}
+
+// Size returns the number of keys in the tree.
+func (t *BPlusTree) Size() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return int(t.meta.KeyCount)
+}
+
+// findLeaf finds the leaf node that should contain the given key.
+func (t *BPlusTree) findLeaf(key []byte) (*Node, error) {
+	node, err := t.getNode(t.meta.RootPageID)
+	if err != nil {
+		return nil, err
+	}
+
+	for !node.IsLeaf() {
+		idx := t.findChildIndex(node, key)
+		node, err = t.getNode(node.Children[idx])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+// findChildIndex finds the index of the child that should contain the key.
+func (t *BPlusTree) findChildIndex(node *Node, key []byte) int {
+	// Binary search for the first key > key
+	lo, hi := 0, int(node.KeyCount)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if bytes.Compare(node.Keys[mid], key) <= 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+// searchInNode searches for a key in a node.
+// Returns the index and whether the key was found.
+func (t *BPlusTree) searchInNode(node *Node, key []byte) (int, bool) {
+	lo, hi := 0, int(node.KeyCount)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		cmp := bytes.Compare(node.Keys[mid], key)
+		if cmp == 0 {
+			return mid, true
+		} else if cmp < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo, false
+}
+
+// insertIntoLeaf inserts a key-value pair into a leaf node at the given index.
+func (t *BPlusTree) insertIntoLeaf(leaf *Node, idx int, key []byte, pos *wal.ChunkPosition) {
+	// Make room for new entry
+	leaf.Keys = append(leaf.Keys, nil)
+	copy(leaf.Keys[idx+1:], leaf.Keys[idx:])
+	leaf.Keys[idx] = key
+
+	leaf.Values = append(leaf.Values, nil)
+	copy(leaf.Values[idx+1:], leaf.Values[idx:])
+	leaf.Values[idx] = pos
+
+	leaf.KeyCount++
+}
+
+// splitLeaf splits a full leaf node.
+func (t *BPlusTree) splitLeaf(leaf *Node) {
+	mid := int(leaf.KeyCount) / 2
+
+	// Create new leaf
+	newLeaf := &Node{
+		PageID:   t.allocatePage(),
+		PageType: PageTypeLeaf,
+		KeyCount: uint16(int(leaf.KeyCount) - mid),
+		Parent:   leaf.Parent,
+		Next:     leaf.Next,
+		Prev:     leaf.PageID,
+		Keys:     make([][]byte, int(leaf.KeyCount)-mid),
+		Values:   make([]*wal.ChunkPosition, int(leaf.KeyCount)-mid),
+		dirty:    true,
+	}
+
+	// Copy second half to new leaf
+	copy(newLeaf.Keys, leaf.Keys[mid:])
+	copy(newLeaf.Values, leaf.Values[mid:])
+
+	// Update old leaf
+	leaf.Keys = leaf.Keys[:mid]
+	leaf.Values = leaf.Values[:mid]
+	leaf.KeyCount = uint16(mid)
+	leaf.Next = newLeaf.PageID
+
+	// Update next leaf's prev pointer
+	if newLeaf.Next != InvalidPageID {
+		nextLeaf, err := t.getNode(newLeaf.Next)
+		if err == nil {
+			nextLeaf.Prev = newLeaf.PageID
+			t.cache.MarkDirty(nextLeaf.PageID)
+		}
+	}
+
+	t.cache.Put(newLeaf)
+	t.cache.MarkDirty(leaf.PageID)
+	t.cache.MarkDirty(newLeaf.PageID)
+
+	// Insert into parent
+	t.insertIntoParent(leaf, newLeaf.Keys[0], newLeaf)
+}
+
+// insertIntoParent inserts a key and new child into the parent node.
+func (t *BPlusTree) insertIntoParent(left *Node, key []byte, right *Node) {
+	if left.Parent == InvalidPageID {
+		// Create new root
+		newRoot := &Node{
+			PageID:   t.allocatePage(),
+			PageType: PageTypeInternal,
+			KeyCount: 1,
+			Parent:   InvalidPageID,
+			Keys:     [][]byte{key},
+			Children: []uint32{left.PageID, right.PageID},
+			dirty:    true,
+		}
+
+		left.Parent = newRoot.PageID
+		right.Parent = newRoot.PageID
+		t.meta.RootPageID = newRoot.PageID
+
+		t.cache.Put(newRoot)
+		t.cache.MarkDirty(newRoot.PageID)
+		t.cache.MarkDirty(left.PageID)
+		t.cache.MarkDirty(right.PageID)
+		return
+	}
+
+	parent, err := t.getNode(left.Parent)
+	if err != nil {
+		return
+	}
+
+	// Find insertion point
+	idx := t.findChildIndex(parent, key)
+
+	// Insert key and child
+	parent.Keys = append(parent.Keys, nil)
+	copy(parent.Keys[idx+1:], parent.Keys[idx:])
+	parent.Keys[idx] = key
+
+	parent.Children = append(parent.Children, 0)
+	copy(parent.Children[idx+2:], parent.Children[idx+1:])
+	parent.Children[idx+1] = right.PageID
+
+	parent.KeyCount++
+	right.Parent = parent.PageID
+
+	t.cache.MarkDirty(parent.PageID)
+	t.cache.MarkDirty(right.PageID)
+
+	// Check if parent needs splitting
+	if int(parent.KeyCount) >= t.order {
+		t.splitInternal(parent)
+	}
+}
+
+// splitInternal splits a full internal node.
+func (t *BPlusTree) splitInternal(node *Node) {
+	mid := int(node.KeyCount) / 2
+
+	// Create new internal node
+	newNode := &Node{
+		PageID:   t.allocatePage(),
+		PageType: PageTypeInternal,
+		KeyCount: uint16(int(node.KeyCount) - mid - 1),
+		Parent:   node.Parent,
+		Keys:     make([][]byte, int(node.KeyCount)-mid-1),
+		Children: make([]uint32, int(node.KeyCount)-mid),
+		dirty:    true,
+	}
+
+	// Key at mid will be promoted to parent
+	promoteKey := node.Keys[mid]
+
+	// Copy second half to new node (excluding the promoted key)
+	copy(newNode.Keys, node.Keys[mid+1:])
+	copy(newNode.Children, node.Children[mid+1:])
+
+	// Update children's parent pointer
+	for _, childID := range newNode.Children {
+		if child, err := t.getNode(childID); err == nil {
+			child.Parent = newNode.PageID
+			t.cache.MarkDirty(child.PageID)
+		}
+	}
+
+	// Update old node
+	node.Keys = node.Keys[:mid]
+	node.Children = node.Children[:mid+1]
+	node.KeyCount = uint16(mid)
+
+	t.cache.Put(newNode)
+	t.cache.MarkDirty(node.PageID)
+	t.cache.MarkDirty(newNode.PageID)
+
+	// Insert into parent
+	t.insertIntoParent(node, promoteKey, newNode)
+}

--- a/index/bptree/bptree_test.go
+++ b/index/bptree/bptree_test.go
@@ -1,0 +1,1252 @@
+package bptree
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rosedblabs/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Basic Operations Tests
+// ============================================================================
+
+func TestBPlusTree_Basic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Test Put and Get
+	pos1 := &wal.ChunkPosition{SegmentId: 1, BlockNumber: 0, ChunkOffset: 0, ChunkSize: 100}
+	oldPos := tree.Put([]byte("key1"), pos1)
+	assert.Nil(t, oldPos)
+
+	got := tree.Get([]byte("key1"))
+	assert.NotNil(t, got)
+	assert.Equal(t, pos1.SegmentId, got.SegmentId)
+	assert.Equal(t, pos1.BlockNumber, got.BlockNumber)
+	assert.Equal(t, pos1.ChunkOffset, got.ChunkOffset)
+	assert.Equal(t, pos1.ChunkSize, got.ChunkSize)
+
+	// Test update
+	pos2 := &wal.ChunkPosition{SegmentId: 2, BlockNumber: 1, ChunkOffset: 100, ChunkSize: 200}
+	oldPos = tree.Put([]byte("key1"), pos2)
+	assert.NotNil(t, oldPos)
+	assert.Equal(t, pos1.SegmentId, oldPos.SegmentId)
+
+	got = tree.Get([]byte("key1"))
+	assert.Equal(t, pos2.SegmentId, got.SegmentId)
+
+	// Test Get non-existent key
+	got = tree.Get([]byte("nonexistent"))
+	assert.Nil(t, got)
+
+	// Test Size
+	assert.Equal(t, 1, tree.Size())
+}
+
+func TestBPlusTree_Delete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	pos := &wal.ChunkPosition{SegmentId: 1, BlockNumber: 0, ChunkOffset: 0, ChunkSize: 100}
+	tree.Put([]byte("key1"), pos)
+
+	// Delete existing key
+	oldPos, deleted := tree.Delete([]byte("key1"))
+	assert.True(t, deleted)
+	assert.NotNil(t, oldPos)
+	assert.Equal(t, pos.SegmentId, oldPos.SegmentId)
+
+	// Verify deleted
+	got := tree.Get([]byte("key1"))
+	assert.Nil(t, got)
+	assert.Equal(t, 0, tree.Size())
+
+	// Delete non-existent key
+	oldPos, deleted = tree.Delete([]byte("nonexistent"))
+	assert.False(t, deleted)
+	assert.Nil(t, oldPos)
+}
+
+func TestBPlusTree_MultipleKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert multiple keys
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	assert.Equal(t, len(keys), tree.Size())
+
+	// Verify all keys
+	for i, key := range keys {
+		got := tree.Get([]byte(key))
+		assert.NotNil(t, got, "key %s should exist", key)
+		assert.Equal(t, uint32(i), got.SegmentId)
+	}
+}
+
+func TestBPlusTree_UpdateMultiple(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert and update multiple times
+	key := []byte("key")
+	for i := 0; i < 100; i++ {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i), ChunkSize: 100}
+		tree.Put(key, pos)
+	}
+
+	// Size should be 1 (same key updated)
+	assert.Equal(t, 1, tree.Size())
+
+	// Value should be the last one
+	got := tree.Get(key)
+	assert.Equal(t, uint32(99), got.SegmentId)
+}
+
+// ============================================================================
+// Empty Tree Tests
+// ============================================================================
+
+func TestBPlusTree_EmptyTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Test operations on empty tree
+	assert.Equal(t, 0, tree.Size())
+	assert.Nil(t, tree.Get([]byte("key")))
+
+	// Delete on empty tree
+	_, deleted := tree.Delete([]byte("key"))
+	assert.False(t, deleted)
+
+	// Iterator on empty tree
+	it := tree.Iterator(false)
+	it.Rewind()
+	assert.False(t, it.Valid())
+	assert.Nil(t, it.Key())
+	assert.Nil(t, it.Value())
+	it.Close()
+}
+
+// ============================================================================
+// Iterator Tests
+// ============================================================================
+
+func TestBPlusTree_Iterator_Forward(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert keys in random order
+	keys := []string{"cherry", "apple", "elderberry", "banana", "date"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Iterate in ascending order
+	it := tree.Iterator(false)
+	defer it.Close()
+
+	expected := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	i := 0
+	for it.Rewind(); it.Valid(); it.Next() {
+		assert.Equal(t, expected[i], string(it.Key()))
+		assert.NotNil(t, it.Value())
+		i++
+	}
+	assert.Equal(t, len(expected), i)
+}
+
+func TestBPlusTree_Iterator_Reverse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Iterate in descending order
+	it := tree.Iterator(true)
+	defer it.Close()
+
+	expected := []string{"elderberry", "date", "cherry", "banana", "apple"}
+	i := 0
+	for it.Rewind(); it.Valid(); it.Next() {
+		assert.Equal(t, expected[i], string(it.Key()))
+		i++
+	}
+	assert.Equal(t, len(expected), i)
+}
+
+func TestBPlusTree_Iterator_Seek(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Seek to existing key
+	it := tree.Iterator(false)
+	it.Seek([]byte("cherry"))
+	assert.True(t, it.Valid())
+	assert.Equal(t, "cherry", string(it.Key()))
+	it.Close()
+
+	// Seek to non-existent key (should find next)
+	it = tree.Iterator(false)
+	it.Seek([]byte("coconut"))
+	assert.True(t, it.Valid())
+	assert.Equal(t, "date", string(it.Key()))
+	it.Close()
+
+	// Seek beyond all keys
+	it = tree.Iterator(false)
+	it.Seek([]byte("zebra"))
+	assert.False(t, it.Valid())
+	it.Close()
+
+	// Seek before all keys
+	it = tree.Iterator(false)
+	it.Seek([]byte("aaa"))
+	assert.True(t, it.Valid())
+	assert.Equal(t, "apple", string(it.Key()))
+	it.Close()
+}
+
+func TestBPlusTree_Iterator_SeekReverse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Seek in reverse mode
+	it := tree.Iterator(true)
+	it.Seek([]byte("cherry"))
+	assert.True(t, it.Valid())
+	assert.Equal(t, "cherry", string(it.Key()))
+
+	// Next should go to banana
+	it.Next()
+	assert.True(t, it.Valid())
+	assert.Equal(t, "banana", string(it.Key()))
+	it.Close()
+}
+
+func TestBPlusTree_Iterator_Rewind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	keys := []string{"apple", "banana", "cherry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	it := tree.Iterator(false)
+
+	// Iterate partially
+	it.Rewind()
+	it.Next()
+	assert.Equal(t, "banana", string(it.Key()))
+
+	// Rewind and iterate again
+	it.Rewind()
+	assert.Equal(t, "apple", string(it.Key()))
+
+	it.Close()
+}
+
+func TestBPlusTree_Iterator_Close(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	tree.Put([]byte("key1"), &wal.ChunkPosition{SegmentId: 1})
+
+	it := tree.Iterator(false)
+	it.Rewind()
+	assert.True(t, it.Valid())
+
+	it.Close()
+	assert.False(t, it.Valid())
+	assert.Nil(t, it.Key())
+	assert.Nil(t, it.Value())
+}
+
+// ============================================================================
+// Persistence Tests
+// ============================================================================
+
+func TestBPlusTree_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Create and populate tree
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+
+	keys := []string{"apple", "banana", "cherry"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: uint32(i), ChunkOffset: int64(i * 100), ChunkSize: uint32(100 + i)}
+		tree.Put([]byte(key), pos)
+	}
+
+	err = tree.Close()
+	require.NoError(t, err)
+
+	// Reopen and verify
+	tree2, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree2.Close()
+
+	assert.Equal(t, len(keys), tree2.Size())
+
+	for i, key := range keys {
+		got := tree2.Get([]byte(key))
+		require.NotNil(t, got, "key %s should exist", key)
+		assert.Equal(t, uint32(i), got.SegmentId)
+		assert.Equal(t, uint32(i), got.BlockNumber)
+		assert.Equal(t, int64(i*100), got.ChunkOffset)
+		assert.Equal(t, uint32(100+i), got.ChunkSize)
+	}
+}
+
+func TestBPlusTree_PersistenceAfterDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Create tree and add keys
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("key%d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Delete some keys
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("key%d", i)
+		tree.Delete([]byte(key))
+	}
+
+	tree.Close()
+
+	// Reopen and verify
+	tree2, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree2.Close()
+
+	assert.Equal(t, 5, tree2.Size())
+
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("key%d", i)
+		assert.Nil(t, tree2.Get([]byte(key)))
+	}
+
+	for i := 5; i < 10; i++ {
+		key := fmt.Sprintf("key%d", i)
+		assert.NotNil(t, tree2.Get([]byte(key)))
+	}
+}
+
+func TestBPlusTree_Sync(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+
+	tree.Put([]byte("key1"), &wal.ChunkPosition{SegmentId: 1})
+
+	err = tree.Sync()
+	assert.NoError(t, err)
+
+	tree.Close()
+
+	// Verify file exists and has content
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+}
+
+// ============================================================================
+// Split Tests
+// ============================================================================
+
+func TestBPlusTree_Split(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Use small order to trigger splits
+	options := DefaultOptions
+	options.Order = 4
+
+	tree, err := Open(path, options)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert enough keys to trigger multiple splits
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("key%03d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	assert.Equal(t, 100, tree.Size())
+
+	// Verify all keys are retrievable
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("key%03d", i)
+		got := tree.Get([]byte(key))
+		assert.NotNil(t, got, "key %s not found", key)
+		assert.Equal(t, uint32(i), got.SegmentId)
+	}
+
+	// Verify iteration order
+	it := tree.Iterator(false)
+	defer it.Close()
+
+	i := 0
+	for it.Rewind(); it.Valid(); it.Next() {
+		expected := fmt.Sprintf("key%03d", i)
+		assert.Equal(t, expected, string(it.Key()))
+		i++
+	}
+	assert.Equal(t, 100, i)
+}
+
+func TestBPlusTree_SplitWithRandomKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	options := DefaultOptions
+	options.Order = 4
+
+	tree, err := Open(path, options)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert random keys
+	rand.Seed(time.Now().UnixNano())
+	keys := make(map[string]*wal.ChunkPosition)
+	for i := 0; i < 200; i++ {
+		key := fmt.Sprintf("key%08d", rand.Int())
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), ChunkOffset: int64(i)}
+		tree.Put([]byte(key), pos)
+		keys[key] = pos
+	}
+
+	// Verify all keys
+	for key, expectedPos := range keys {
+		got := tree.Get([]byte(key))
+		assert.NotNil(t, got, "key %s not found", key)
+		assert.Equal(t, expectedPos.SegmentId, got.SegmentId)
+	}
+}
+
+// ============================================================================
+// Edge Cases Tests
+// ============================================================================
+
+func TestBPlusTree_EmptyKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Empty key should work
+	pos := &wal.ChunkPosition{SegmentId: 1}
+	tree.Put([]byte(""), pos)
+
+	got := tree.Get([]byte(""))
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(1), got.SegmentId)
+}
+
+func TestBPlusTree_LargeKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Large key (512 bytes)
+	largeKey := make([]byte, 512)
+	for i := range largeKey {
+		largeKey[i] = byte(i % 256)
+	}
+
+	pos := &wal.ChunkPosition{SegmentId: 1}
+	tree.Put(largeKey, pos)
+
+	got := tree.Get(largeKey)
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(1), got.SegmentId)
+}
+
+func TestBPlusTree_BinaryKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Binary key with null bytes
+	key := []byte{0x00, 0x01, 0x02, 0x00, 0x03}
+	pos := &wal.ChunkPosition{SegmentId: 1}
+	tree.Put(key, pos)
+
+	got := tree.Get(key)
+	assert.NotNil(t, got)
+}
+
+func TestBPlusTree_NilValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Nil value should not crash
+	tree.Put([]byte("key"), nil)
+
+	got := tree.Get([]byte("key"))
+	// Behavior depends on implementation
+	_ = got
+}
+
+// ============================================================================
+// Concurrent Tests
+// ============================================================================
+
+func TestBPlusTree_ConcurrentPut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	keysPerGoroutine := 100
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < keysPerGoroutine; i++ {
+				key := fmt.Sprintf("g%d-key%d", gid, i)
+				pos := &wal.ChunkPosition{SegmentId: uint32(gid*1000 + i)}
+				tree.Put([]byte(key), pos)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, numGoroutines*keysPerGoroutine, tree.Size())
+}
+
+func TestBPlusTree_ConcurrentGet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	// Insert keys first
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprintf("key%d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+		tree.Put([]byte(key), pos)
+	}
+
+	// Concurrent reads
+	var wg sync.WaitGroup
+	numGoroutines := 10
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				key := fmt.Sprintf("key%d", i)
+				got := tree.Get([]byte(key))
+				assert.NotNil(t, got)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestBPlusTree_ConcurrentReadWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree.Close()
+
+	var wg sync.WaitGroup
+
+	// Writers
+	for g := 0; g < 5; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				key := fmt.Sprintf("writer%d-key%d", gid, i)
+				pos := &wal.ChunkPosition{SegmentId: uint32(gid*1000 + i)}
+				tree.Put([]byte(key), pos)
+			}
+		}(g)
+	}
+
+	// Readers
+	for g := 0; g < 5; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				key := fmt.Sprintf("writer%d-key%d", gid, rand.Intn(100))
+				tree.Get([]byte(key))
+			}
+		}(g)
+	}
+
+	wg.Wait()
+}
+
+// ============================================================================
+// File Operations Tests
+// ============================================================================
+
+func TestBPlusTree_FileCreation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Verify file doesn't exist
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+
+	tree, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+
+	// Verify file was created
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+
+	tree.Close()
+}
+
+func TestBPlusTree_OpenExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Create and populate
+	tree1, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	tree1.Put([]byte("key1"), &wal.ChunkPosition{SegmentId: 1})
+	tree1.Close()
+
+	// Open existing
+	tree2, err := Open(path, DefaultOptions)
+	require.NoError(t, err)
+	defer tree2.Close()
+
+	got := tree2.Get([]byte("key1"))
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(1), got.SegmentId)
+}
+
+func TestBPlusTree_CorruptedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.index")
+
+	// Create a corrupted file
+	err := os.WriteFile(path, []byte("corrupted data"), 0644)
+	require.NoError(t, err)
+
+	// Should fail to open
+	_, err = Open(path, DefaultOptions)
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// Indexer Interface Tests
+// ============================================================================
+
+func TestBPTreeIndexer(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	// Test Put and Get
+	pos1 := &wal.ChunkPosition{SegmentId: 1, BlockNumber: 0, ChunkOffset: 0, ChunkSize: 100}
+	indexer.Put([]byte("key1"), pos1)
+
+	got := indexer.Get([]byte("key1"))
+	assert.NotNil(t, got)
+	assert.Equal(t, pos1.SegmentId, got.SegmentId)
+
+	// Test Size
+	assert.Equal(t, 1, indexer.Size())
+
+	// Test Delete
+	oldPos, deleted := indexer.Delete([]byte("key1"))
+	assert.True(t, deleted)
+	assert.NotNil(t, oldPos)
+
+	got = indexer.Get([]byte("key1"))
+	assert.Nil(t, got)
+}
+
+func TestBPTreeIndexer_Ascend(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"cherry", "apple", "banana", "date"}
+	for i, key := range keys {
+		pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+		indexer.Put([]byte(key), pos)
+	}
+
+	var result []string
+	indexer.Ascend(func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	assert.Equal(t, []string{"apple", "banana", "cherry", "date"}, result)
+}
+
+func TestBPTreeIndexer_AscendEarlyStop(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("key%02d", i)
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.Ascend(func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return len(result) < 3, nil // stop after 3
+	})
+
+	assert.Equal(t, 3, len(result))
+}
+
+func TestBPTreeIndexer_Descend(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"apple", "banana", "cherry"}
+	for i, key := range keys {
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.Descend(func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	assert.Equal(t, []string{"cherry", "banana", "apple"}, result)
+}
+
+func TestBPTreeIndexer_AscendRange(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.AscendRange([]byte("banana"), []byte("elderberry"), func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	assert.Equal(t, []string{"banana", "cherry", "date"}, result)
+}
+
+func TestBPTreeIndexer_AscendGreaterOrEqual(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.AscendGreaterOrEqual([]byte("cherry"), func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	assert.Equal(t, []string{"cherry", "date", "elderberry"}, result)
+}
+
+func TestBPTreeIndexer_DescendRange(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.DescendRange([]byte("elderberry"), []byte("banana"), func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	// Should include elderberry, date, cherry (not banana as it's the end)
+	assert.True(t, len(result) >= 2)
+	assert.Equal(t, "elderberry", result[0])
+}
+
+func TestBPTreeIndexer_DescendLessOrEqual(t *testing.T) {
+	dir := t.TempDir()
+
+	indexer, err := NewBPTreeIndexer(dir, DefaultOptions)
+	require.NoError(t, err)
+	defer indexer.Close()
+
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for i, key := range keys {
+		indexer.Put([]byte(key), &wal.ChunkPosition{SegmentId: uint32(i)})
+	}
+
+	var result []string
+	indexer.DescendLessOrEqual([]byte("cherry"), func(key []byte, pos *wal.ChunkPosition) (bool, error) {
+		result = append(result, string(key))
+		return true, nil
+	})
+
+	assert.Equal(t, []string{"cherry", "banana", "apple"}, result)
+}
+
+// ============================================================================
+// Page Serialization Tests
+// ============================================================================
+
+func TestMetaPage_Serialization(t *testing.T) {
+	meta := &MetaPage{
+		Magic:        MagicNumber,
+		Version:      Version,
+		PageSize:     4096,
+		RootPageID:   1,
+		FreeListPage: 2,
+		KeyCount:     100,
+		PageCount:    50,
+	}
+
+	data := meta.Serialize()
+	assert.Equal(t, metaPageSize, len(data))
+
+	restored, err := DeserializeMetaPage(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, meta.Magic, restored.Magic)
+	assert.Equal(t, meta.Version, restored.Version)
+	assert.Equal(t, meta.PageSize, restored.PageSize)
+	assert.Equal(t, meta.RootPageID, restored.RootPageID)
+	assert.Equal(t, meta.FreeListPage, restored.FreeListPage)
+	assert.Equal(t, meta.KeyCount, restored.KeyCount)
+	assert.Equal(t, meta.PageCount, restored.PageCount)
+}
+
+func TestNode_LeafSerialization(t *testing.T) {
+	node := &Node{
+		PageID:   1,
+		PageType: PageTypeLeaf,
+		KeyCount: 2,
+		Parent:   0,
+		Next:     2,
+		Prev:     0,
+		Keys:     [][]byte{[]byte("key1"), []byte("key2")},
+		Values: []*wal.ChunkPosition{
+			{SegmentId: 1, BlockNumber: 0, ChunkOffset: 0, ChunkSize: 100},
+			{SegmentId: 2, BlockNumber: 1, ChunkOffset: 100, ChunkSize: 200},
+		},
+	}
+
+	data := node.Serialize(4096)
+	assert.Equal(t, 4096, len(data))
+
+	restored, err := DeserializeNode(1, data)
+	require.NoError(t, err)
+
+	assert.Equal(t, node.PageID, restored.PageID)
+	assert.Equal(t, node.PageType, restored.PageType)
+	assert.Equal(t, node.KeyCount, restored.KeyCount)
+	assert.Equal(t, node.Next, restored.Next)
+	assert.True(t, bytes.Equal(node.Keys[0], restored.Keys[0]))
+	assert.True(t, bytes.Equal(node.Keys[1], restored.Keys[1]))
+	assert.Equal(t, node.Values[0].SegmentId, restored.Values[0].SegmentId)
+	assert.Equal(t, node.Values[1].ChunkSize, restored.Values[1].ChunkSize)
+}
+
+func TestNode_InternalSerialization(t *testing.T) {
+	node := &Node{
+		PageID:   1,
+		PageType: PageTypeInternal,
+		KeyCount: 2,
+		Parent:   0,
+		Keys:     [][]byte{[]byte("key1"), []byte("key2")},
+		Children: []uint32{2, 3, 4},
+	}
+
+	data := node.Serialize(4096)
+	restored, err := DeserializeNode(1, data)
+	require.NoError(t, err)
+
+	assert.Equal(t, node.PageType, restored.PageType)
+	assert.Equal(t, node.KeyCount, restored.KeyCount)
+	assert.True(t, bytes.Equal(node.Keys[0], restored.Keys[0]))
+	assert.Equal(t, node.Children[0], restored.Children[0])
+	assert.Equal(t, node.Children[2], restored.Children[2])
+}
+
+// ============================================================================
+// Cache Tests
+// ============================================================================
+
+func TestPageCache_Basic(t *testing.T) {
+	cache := NewPageCache(10, 4096, nil)
+
+	node := &Node{PageID: 1, PageType: PageTypeLeaf}
+	cache.Put(node)
+
+	got := cache.Get(1)
+	assert.NotNil(t, got)
+	assert.Equal(t, uint32(1), got.PageID)
+
+	// Non-existent page
+	got = cache.Get(999)
+	assert.Nil(t, got)
+}
+
+func TestPageCache_LRU(t *testing.T) {
+	cache := NewPageCache(3, 4096, nil)
+
+	// Add 3 pages
+	for i := uint32(1); i <= 3; i++ {
+		cache.Put(&Node{PageID: i})
+	}
+
+	assert.Equal(t, 3, cache.Len())
+
+	// Add 4th page, should evict page 1
+	cache.Put(&Node{PageID: 4})
+	assert.Equal(t, 3, cache.Len())
+
+	// Page 1 should be evicted
+	assert.Nil(t, cache.Get(1))
+
+	// Pages 2, 3, 4 should exist
+	assert.NotNil(t, cache.Get(2))
+	assert.NotNil(t, cache.Get(3))
+	assert.NotNil(t, cache.Get(4))
+}
+
+func TestPageCache_Dirty(t *testing.T) {
+	cache := NewPageCache(10, 4096, nil)
+
+	node := &Node{PageID: 1}
+	cache.Put(node)
+
+	assert.False(t, cache.IsDirty(1))
+
+	cache.MarkDirty(1)
+	assert.True(t, cache.IsDirty(1))
+
+	cache.ClearDirty(1)
+	assert.False(t, cache.IsDirty(1))
+}
+
+func TestPageCache_GetDirtyPages(t *testing.T) {
+	cache := NewPageCache(10, 4096, nil)
+
+	for i := uint32(1); i <= 5; i++ {
+		cache.Put(&Node{PageID: i})
+	}
+
+	cache.MarkDirty(1)
+	cache.MarkDirty(3)
+	cache.MarkDirty(5)
+
+	dirtyPages := cache.GetDirtyPages()
+	assert.Equal(t, 3, len(dirtyPages))
+}
+
+func TestPageCache_Remove(t *testing.T) {
+	cache := NewPageCache(10, 4096, nil)
+
+	cache.Put(&Node{PageID: 1})
+	cache.MarkDirty(1)
+
+	cache.Remove(1)
+
+	assert.Nil(t, cache.Get(1))
+	assert.False(t, cache.IsDirty(1))
+}
+
+// ============================================================================
+// FreeList Tests
+// ============================================================================
+
+func TestFreeList_Basic(t *testing.T) {
+	fl := NewFreeList()
+
+	assert.Equal(t, 0, fl.Count())
+	assert.Equal(t, uint32(0), fl.Allocate())
+
+	fl.Free(1)
+	fl.Free(2)
+	fl.Free(3)
+
+	assert.Equal(t, 3, fl.Count())
+
+	// Should return in LIFO order
+	assert.Equal(t, uint32(3), fl.Allocate())
+	assert.Equal(t, uint32(2), fl.Allocate())
+	assert.Equal(t, uint32(1), fl.Allocate())
+	assert.Equal(t, uint32(0), fl.Allocate())
+}
+
+func TestFreeList_Serialization(t *testing.T) {
+	fl := NewFreeList()
+	fl.Free(10)
+	fl.Free(20)
+	fl.Free(30)
+
+	data := fl.Serialize(4096)
+	restored := DeserializeFreeList(data)
+
+	assert.Equal(t, fl.Count(), restored.Count())
+	assert.Equal(t, fl.Allocate(), restored.Allocate())
+	assert.Equal(t, fl.Allocate(), restored.Allocate())
+}
+
+// ============================================================================
+// Benchmark Tests
+// ============================================================================
+
+func BenchmarkBPlusTree_Put(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.index")
+
+	tree, err := Open(path, DefaultOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tree.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key%010d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+}
+
+func BenchmarkBPlusTree_Get(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.index")
+
+	tree, err := Open(path, DefaultOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tree.Close()
+
+	// Populate tree
+	for i := 0; i < 100000; i++ {
+		key := fmt.Sprintf("key%010d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i), BlockNumber: 0, ChunkOffset: int64(i * 100), ChunkSize: 100}
+		tree.Put([]byte(key), pos)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key%010d", i%100000)
+		tree.Get([]byte(key))
+	}
+}
+
+func BenchmarkBPlusTree_Delete(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.index")
+
+	tree, err := Open(path, DefaultOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tree.Close()
+
+	// Populate tree
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key%010d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+		tree.Put([]byte(key), pos)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := fmt.Sprintf("key%010d", i)
+		tree.Delete([]byte(key))
+	}
+}
+
+func BenchmarkBPlusTree_Iterator(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.index")
+
+	tree, err := Open(path, DefaultOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tree.Close()
+
+	// Populate tree
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("key%010d", i)
+		pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+		tree.Put([]byte(key), pos)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		it := tree.Iterator(false)
+		for it.Rewind(); it.Valid(); it.Next() {
+			_ = it.Key()
+			_ = it.Value()
+		}
+		it.Close()
+	}
+}
+
+func BenchmarkBPlusTree_ConcurrentPut(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.index")
+
+	tree, err := Open(path, DefaultOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tree.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			key := fmt.Sprintf("key%010d", rand.Int())
+			pos := &wal.ChunkPosition{SegmentId: uint32(i)}
+			tree.Put([]byte(key), pos)
+			i++
+		}
+	})
+}

--- a/index/bptree/cache.go
+++ b/index/bptree/cache.go
@@ -1,0 +1,177 @@
+package bptree
+
+import (
+	"container/list"
+	"sync"
+)
+
+// FlushFunc is a function that writes a page to disk.
+type FlushFunc func(pageID uint32, data []byte) error
+
+// PageCache is an LRU cache for B+Tree pages.
+type PageCache struct {
+	capacity int
+	cache    map[uint32]*list.Element
+	lru      *list.List
+	dirty    map[uint32]bool // track dirty pages
+	mu       sync.RWMutex
+	flushFn  FlushFunc // callback to flush dirty pages
+	pageSize uint32
+}
+
+type cacheEntry struct {
+	pageID uint32
+	node   *Node
+}
+
+// NewPageCache creates a new page cache with the given capacity.
+func NewPageCache(capacity int, pageSize uint32, flushFn FlushFunc) *PageCache {
+	return &PageCache{
+		capacity: capacity,
+		cache:    make(map[uint32]*list.Element),
+		lru:      list.New(),
+		dirty:    make(map[uint32]bool),
+		flushFn:  flushFn,
+		pageSize: pageSize,
+	}
+}
+
+// Get retrieves a page from the cache.
+func (c *PageCache) Get(pageID uint32) *Node {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.cache[pageID]; ok {
+		c.lru.MoveToFront(elem)
+		return elem.Value.(*cacheEntry).node
+	}
+	return nil
+}
+
+// Put adds a page to the cache.
+func (c *PageCache) Put(node *Node) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.cache[node.PageID]; ok {
+		c.lru.MoveToFront(elem)
+		elem.Value.(*cacheEntry).node = node
+		return
+	}
+
+	// Evict if at capacity
+	if c.lru.Len() >= c.capacity {
+		c.evictLocked()
+	}
+
+	entry := &cacheEntry{pageID: node.PageID, node: node}
+	elem := c.lru.PushFront(entry)
+	c.cache[node.PageID] = elem
+}
+
+// MarkDirty marks a page as dirty.
+func (c *PageCache) MarkDirty(pageID uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dirty[pageID] = true
+}
+
+// IsDirty checks if a page is dirty.
+func (c *PageCache) IsDirty(pageID uint32) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.dirty[pageID]
+}
+
+// ClearDirty clears the dirty flag for a page.
+func (c *PageCache) ClearDirty(pageID uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.dirty, pageID)
+}
+
+// GetDirtyPages returns all dirty page IDs.
+func (c *PageCache) GetDirtyPages() []uint32 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	pages := make([]uint32, 0, len(c.dirty))
+	for pageID := range c.dirty {
+		pages = append(pages, pageID)
+	}
+	return pages
+}
+
+// Remove removes a page from the cache.
+func (c *PageCache) Remove(pageID uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.cache[pageID]; ok {
+		c.lru.Remove(elem)
+		delete(c.cache, pageID)
+		delete(c.dirty, pageID)
+	}
+}
+
+// evictLocked evicts the least recently used page.
+// Must be called with lock held.
+// If the page is dirty, it will be flushed to disk before eviction.
+func (c *PageCache) evictLocked() *Node {
+	elem := c.lru.Back()
+	if elem == nil {
+		return nil
+	}
+
+	entry := elem.Value.(*cacheEntry)
+
+	// Flush dirty page before eviction
+	if c.dirty[entry.pageID] && c.flushFn != nil {
+		data := entry.node.Serialize(c.pageSize)
+		_ = c.flushFn(entry.pageID, data)
+		delete(c.dirty, entry.pageID)
+	}
+
+	c.lru.Remove(elem)
+	delete(c.cache, entry.pageID)
+
+	return entry.node
+}
+
+// EvictDirty returns a dirty page to be flushed if the cache is full.
+// Returns nil if no eviction is needed.
+func (c *PageCache) EvictDirty() *Node {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.lru.Len() < c.capacity {
+		return nil
+	}
+
+	// Find the LRU dirty page
+	for elem := c.lru.Back(); elem != nil; elem = elem.Prev() {
+		entry := elem.Value.(*cacheEntry)
+		if c.dirty[entry.pageID] {
+			return entry.node
+		}
+	}
+
+	return nil
+}
+
+// Clear clears the cache.
+func (c *PageCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache = make(map[uint32]*list.Element)
+	c.lru = list.New()
+	c.dirty = make(map[uint32]bool)
+}
+
+// Len returns the number of pages in the cache.
+func (c *PageCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lru.Len()
+}

--- a/index/bptree/freelist.go
+++ b/index/bptree/freelist.go
@@ -1,0 +1,86 @@
+package bptree
+
+import (
+	"encoding/binary"
+	"sync"
+)
+
+// FreeList manages free pages in the B+Tree file.
+// It uses a simple linked list of page IDs.
+type FreeList struct {
+	pageIDs []uint32
+	mu      sync.Mutex
+}
+
+// NewFreeList creates a new free list.
+func NewFreeList() *FreeList {
+	return &FreeList{
+		pageIDs: make([]uint32, 0),
+	}
+}
+
+// Allocate returns a free page ID, or 0 if none available.
+func (f *FreeList) Allocate() uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.pageIDs) == 0 {
+		return 0
+	}
+
+	pageID := f.pageIDs[len(f.pageIDs)-1]
+	f.pageIDs = f.pageIDs[:len(f.pageIDs)-1]
+	return pageID
+}
+
+// Free adds a page ID to the free list.
+func (f *FreeList) Free(pageID uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.pageIDs = append(f.pageIDs, pageID)
+}
+
+// Count returns the number of free pages.
+func (f *FreeList) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pageIDs)
+}
+
+// Serialize serializes the free list to bytes.
+// Format: [count(4)][pageID1(4)][pageID2(4)]...
+func (f *FreeList) Serialize(pageSize uint32) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	buf := make([]byte, pageSize)
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(f.pageIDs)))
+
+	offset := 4
+	for _, pageID := range f.pageIDs {
+		if offset+4 > int(pageSize) {
+			break // page full, would need overflow handling for large free lists
+		}
+		binary.LittleEndian.PutUint32(buf[offset:offset+4], pageID)
+		offset += 4
+	}
+
+	return buf
+}
+
+// Deserialize deserializes bytes to a free list.
+func DeserializeFreeList(buf []byte) *FreeList {
+	count := binary.LittleEndian.Uint32(buf[0:4])
+	pageIDs := make([]uint32, count)
+
+	offset := 4
+	for i := uint32(0); i < count && offset+4 <= len(buf); i++ {
+		pageIDs[i] = binary.LittleEndian.Uint32(buf[offset : offset+4])
+		offset += 4
+	}
+
+	return &FreeList{
+		pageIDs: pageIDs,
+	}
+}

--- a/index/bptree/indexer.go
+++ b/index/bptree/indexer.go
@@ -1,0 +1,156 @@
+package bptree
+
+import (
+	"bytes"
+	"path/filepath"
+
+	"github.com/rosedblabs/rosedb/v2/index"
+	"github.com/rosedblabs/wal"
+)
+
+const indexFileName = "bptree.index"
+
+// BPTreeIndexer is an adapter that implements the Indexer interface using B+Tree.
+type BPTreeIndexer struct {
+	tree *BPlusTree
+}
+
+// NewBPTreeIndexer creates a new B+Tree indexer.
+func NewBPTreeIndexer(dirPath string, options Options) (*BPTreeIndexer, error) {
+	indexPath := filepath.Join(dirPath, indexFileName)
+	tree, err := Open(indexPath, options)
+	if err != nil {
+		return nil, err
+	}
+	return &BPTreeIndexer{tree: tree}, nil
+}
+
+// Put inserts or updates a key-value pair.
+func (idx *BPTreeIndexer) Put(key []byte, position *wal.ChunkPosition) *wal.ChunkPosition {
+	return idx.tree.Put(key, position)
+}
+
+// Get retrieves the value for a key.
+func (idx *BPTreeIndexer) Get(key []byte) *wal.ChunkPosition {
+	return idx.tree.Get(key)
+}
+
+// Delete removes a key from the index.
+func (idx *BPTreeIndexer) Delete(key []byte) (*wal.ChunkPosition, bool) {
+	return idx.tree.Delete(key)
+}
+
+// Size returns the number of keys in the index.
+func (idx *BPTreeIndexer) Size() int {
+	return idx.tree.Size()
+}
+
+// Close closes the B+Tree.
+func (idx *BPTreeIndexer) Close() error {
+	return idx.tree.Close()
+}
+
+// Sync flushes all dirty pages to disk.
+func (idx *BPTreeIndexer) Sync() error {
+	return idx.tree.Sync()
+}
+
+// Ascend iterates over all key-value pairs in ascending order.
+func (idx *BPTreeIndexer) Ascend(handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(false)
+	defer it.Close()
+
+	for it.Rewind(); it.Valid(); it.Next() {
+		cont, err := handleFn(it.Key(), it.Value())
+		if err != nil || !cont {
+			break
+		}
+	}
+}
+
+// AscendRange iterates over key-value pairs in [startKey, endKey) in ascending order.
+func (idx *BPTreeIndexer) AscendRange(startKey, endKey []byte, handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(false)
+	defer it.Close()
+
+	it.Seek(startKey)
+	for it.Valid() {
+		key := it.Key()
+		if bytes.Compare(key, endKey) >= 0 {
+			break
+		}
+		cont, err := handleFn(key, it.Value())
+		if err != nil || !cont {
+			break
+		}
+		it.Next()
+	}
+}
+
+// AscendGreaterOrEqual iterates over key-value pairs where key >= given key in ascending order.
+func (idx *BPTreeIndexer) AscendGreaterOrEqual(key []byte, handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(false)
+	defer it.Close()
+
+	it.Seek(key)
+	for it.Valid() {
+		cont, err := handleFn(it.Key(), it.Value())
+		if err != nil || !cont {
+			break
+		}
+		it.Next()
+	}
+}
+
+// Descend iterates over all key-value pairs in descending order.
+func (idx *BPTreeIndexer) Descend(handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(true)
+	defer it.Close()
+
+	for it.Rewind(); it.Valid(); it.Next() {
+		cont, err := handleFn(it.Key(), it.Value())
+		if err != nil || !cont {
+			break
+		}
+	}
+}
+
+// DescendRange iterates over key-value pairs in (endKey, startKey] in descending order.
+// startKey is inclusive (upper bound), endKey is exclusive (lower bound).
+func (idx *BPTreeIndexer) DescendRange(startKey, endKey []byte, handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(true)
+	defer it.Close()
+
+	it.Seek(startKey)
+	for it.Valid() {
+		key := it.Key()
+		if bytes.Compare(key, endKey) <= 0 {
+			break
+		}
+		cont, err := handleFn(key, it.Value())
+		if err != nil || !cont {
+			break
+		}
+		it.Next()
+	}
+}
+
+// DescendLessOrEqual iterates over key-value pairs where key <= given key in descending order.
+func (idx *BPTreeIndexer) DescendLessOrEqual(key []byte, handleFn func(key []byte, position *wal.ChunkPosition) (bool, error)) {
+	it := idx.tree.Iterator(true)
+	defer it.Close()
+
+	it.Seek(key)
+	for it.Valid() {
+		cont, err := handleFn(it.Key(), it.Value())
+		if err != nil || !cont {
+			break
+		}
+		it.Next()
+	}
+}
+
+// Iterator returns an iterator for the index.
+func (idx *BPTreeIndexer) Iterator(reverse bool) index.IndexIterator {
+	return idx.tree.Iterator(reverse)
+}

--- a/index/bptree/iterator.go
+++ b/index/bptree/iterator.go
@@ -1,0 +1,216 @@
+package bptree
+
+import (
+	"github.com/rosedblabs/wal"
+)
+
+// Iterator represents a B+Tree iterator.
+type Iterator struct {
+	tree    *BPlusTree
+	current *Node
+	index   int
+	reverse bool
+	valid   bool
+}
+
+// NewIterator creates a new iterator.
+func (t *BPlusTree) Iterator(reverse bool) *Iterator {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	it := &Iterator{
+		tree:    t,
+		reverse: reverse,
+	}
+
+	it.rewindLocked()
+	return it
+}
+
+// Rewind resets the iterator to the beginning.
+func (it *Iterator) Rewind() {
+	it.tree.mu.RLock()
+	defer it.tree.mu.RUnlock()
+	it.rewindLocked()
+}
+
+func (it *Iterator) rewindLocked() {
+	if it.tree.meta.KeyCount == 0 {
+		it.valid = false
+		return
+	}
+
+	if it.reverse {
+		// Find rightmost leaf
+		node, err := it.tree.getNode(it.tree.meta.RootPageID)
+		if err != nil {
+			it.valid = false
+			return
+		}
+
+		for !node.IsLeaf() {
+			node, err = it.tree.getNode(node.Children[node.KeyCount])
+			if err != nil {
+				it.valid = false
+				return
+			}
+		}
+
+		it.current = node
+		it.index = int(node.KeyCount) - 1
+		it.valid = it.index >= 0
+	} else {
+		// Find leftmost leaf
+		node, err := it.tree.getNode(it.tree.meta.RootPageID)
+		if err != nil {
+			it.valid = false
+			return
+		}
+
+		for !node.IsLeaf() {
+			node, err = it.tree.getNode(node.Children[0])
+			if err != nil {
+				it.valid = false
+				return
+			}
+		}
+
+		it.current = node
+		it.index = 0
+		it.valid = node.KeyCount > 0
+	}
+}
+
+// Seek positions the iterator at the first key >= given key.
+func (it *Iterator) Seek(key []byte) {
+	it.tree.mu.RLock()
+	defer it.tree.mu.RUnlock()
+
+	leaf, err := it.tree.findLeaf(key)
+	if err != nil {
+		it.valid = false
+		return
+	}
+
+	idx, found := it.tree.searchInNode(leaf, key)
+	it.current = leaf
+
+	if it.reverse {
+		if found {
+			it.index = idx
+		} else if idx > 0 {
+			it.index = idx - 1
+		} else {
+			// Need to go to previous leaf
+			if leaf.Prev != InvalidPageID {
+				prevLeaf, err := it.tree.getNode(leaf.Prev)
+				if err != nil {
+					it.valid = false
+					return
+				}
+				it.current = prevLeaf
+				it.index = int(prevLeaf.KeyCount) - 1
+			} else {
+				it.valid = false
+				return
+			}
+		}
+	} else {
+		it.index = idx
+		if idx >= int(leaf.KeyCount) {
+			// Need to go to next leaf
+			if leaf.Next != InvalidPageID {
+				nextLeaf, err := it.tree.getNode(leaf.Next)
+				if err != nil {
+					it.valid = false
+					return
+				}
+				it.current = nextLeaf
+				it.index = 0
+			} else {
+				it.valid = false
+				return
+			}
+		}
+	}
+
+	it.valid = it.current != nil && it.index >= 0 && it.index < int(it.current.KeyCount)
+}
+
+// Next advances the iterator to the next entry.
+func (it *Iterator) Next() {
+	if !it.valid {
+		return
+	}
+
+	it.tree.mu.RLock()
+	defer it.tree.mu.RUnlock()
+
+	if it.reverse {
+		it.index--
+		if it.index < 0 {
+			// Move to previous leaf
+			if it.current.Prev != InvalidPageID {
+				prevLeaf, err := it.tree.getNode(it.current.Prev)
+				if err != nil {
+					it.valid = false
+					return
+				}
+				it.current = prevLeaf
+				it.index = int(prevLeaf.KeyCount) - 1
+			} else {
+				it.valid = false
+			}
+		}
+	} else {
+		it.index++
+		if it.index >= int(it.current.KeyCount) {
+			// Move to next leaf
+			if it.current.Next != InvalidPageID {
+				nextLeaf, err := it.tree.getNode(it.current.Next)
+				if err != nil {
+					it.valid = false
+					return
+				}
+				it.current = nextLeaf
+				it.index = 0
+				if it.current.KeyCount == 0 {
+					it.valid = false
+				}
+			} else {
+				it.valid = false
+			}
+		}
+	}
+}
+
+// Valid returns true if the iterator is positioned at a valid entry.
+func (it *Iterator) Valid() bool {
+	return it.valid
+}
+
+// Key returns the current key.
+func (it *Iterator) Key() []byte {
+	if !it.valid {
+		return nil
+	}
+	it.tree.mu.RLock()
+	defer it.tree.mu.RUnlock()
+	return it.current.Keys[it.index]
+}
+
+// Value returns the current value.
+func (it *Iterator) Value() *wal.ChunkPosition {
+	if !it.valid {
+		return nil
+	}
+	it.tree.mu.RLock()
+	defer it.tree.mu.RUnlock()
+	return it.current.Values[it.index]
+}
+
+// Close releases the iterator resources.
+func (it *Iterator) Close() {
+	it.current = nil
+	it.valid = false
+}

--- a/index/bptree/options.go
+++ b/index/bptree/options.go
@@ -1,0 +1,45 @@
+package bptree
+
+// Options represents the configuration options for B+Tree.
+type Options struct {
+	// PageSize is the size of each page in bytes.
+	// Default is 4KB, must be a power of 2.
+	PageSize uint32
+
+	// Order is the maximum number of children per internal node.
+	// For leaf nodes, it's the maximum number of key-value pairs.
+	// Default is calculated based on PageSize.
+	Order int
+
+	// CacheSize is the maximum number of pages to cache in memory.
+	// Default is 1000 pages.
+	CacheSize int
+
+	// SyncWrites determines whether to sync writes to disk immediately.
+	// Default is false for better performance.
+	SyncWrites bool
+}
+
+// DefaultOptions returns the default options for B+Tree.
+var DefaultOptions = Options{
+	PageSize:   4096,
+	Order:      0, // will be calculated based on PageSize
+	CacheSize:  1000,
+	SyncWrites: false,
+}
+
+// calculateOrder calculates the order based on page size.
+// For leaf nodes: each entry = key_len(4) + key(avg 64) + value(20) = ~88 bytes
+// For internal nodes: each entry = key_len(4) + key(avg 64) + child_ptr(4) = ~72 bytes
+// We use a conservative estimate to ensure nodes fit in a page.
+func calculateOrder(pageSize uint32) int {
+	// Reserve space for node header (32 bytes) and some padding
+	usableSize := int(pageSize) - nodeHeaderSize
+	// Average entry size estimate
+	avgEntrySize := 100
+	order := usableSize / avgEntrySize
+	if order < 4 {
+		order = 4 // minimum order
+	}
+	return order
+}

--- a/index/bptree/page.go
+++ b/index/bptree/page.go
@@ -1,0 +1,255 @@
+package bptree
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/rosedblabs/wal"
+)
+
+const (
+	// Magic number for identifying B+Tree index files
+	MagicNumber uint32 = 0x42505449 // "BPTI"
+
+	// Version of the B+Tree format
+	Version uint16 = 1
+
+	// Page types
+	PageTypeMeta     uint8 = 0
+	PageTypeInternal uint8 = 1
+	PageTypeLeaf     uint8 = 2
+	PageTypeFreeList uint8 = 3
+
+	// Size constants
+	metaPageSize   = 64
+	nodeHeaderSize = 32
+
+	// Invalid page ID
+	InvalidPageID uint32 = 0
+)
+
+var (
+	ErrInvalidMagic   = errors.New("invalid magic number")
+	ErrInvalidVersion = errors.New("unsupported version")
+	ErrInvalidPage    = errors.New("invalid page")
+	ErrKeyTooLarge    = errors.New("key is too large")
+	ErrKeyNotFound    = errors.New("key not found")
+)
+
+// MetaPage represents the metadata page of the B+Tree.
+// Layout (64 bytes):
+// +--------+--------+--------+--------+--------+--------+--------+--------+
+// | Magic(4)| Ver(2)| PgSize(4)| Root(4)| FreeList(4)| KeyCount(8)| ...   |
+// +--------+--------+--------+--------+--------+--------+--------+--------+
+type MetaPage struct {
+	Magic        uint32
+	Version      uint16
+	PageSize     uint32
+	RootPageID   uint32
+	FreeListPage uint32
+	KeyCount     uint64
+	PageCount    uint32
+}
+
+// Serialize serializes the meta page to bytes.
+func (m *MetaPage) Serialize() []byte {
+	buf := make([]byte, metaPageSize)
+	binary.LittleEndian.PutUint32(buf[0:4], m.Magic)
+	binary.LittleEndian.PutUint16(buf[4:6], m.Version)
+	binary.LittleEndian.PutUint32(buf[6:10], m.PageSize)
+	binary.LittleEndian.PutUint32(buf[10:14], m.RootPageID)
+	binary.LittleEndian.PutUint32(buf[14:18], m.FreeListPage)
+	binary.LittleEndian.PutUint64(buf[18:26], m.KeyCount)
+	binary.LittleEndian.PutUint32(buf[26:30], m.PageCount)
+	return buf
+}
+
+// DeserializeMetaPage deserializes bytes to a meta page.
+func DeserializeMetaPage(buf []byte) (*MetaPage, error) {
+	if len(buf) < metaPageSize {
+		return nil, ErrInvalidPage
+	}
+
+	magic := binary.LittleEndian.Uint32(buf[0:4])
+	if magic != MagicNumber {
+		return nil, ErrInvalidMagic
+	}
+
+	version := binary.LittleEndian.Uint16(buf[4:6])
+	if version != Version {
+		return nil, ErrInvalidVersion
+	}
+
+	return &MetaPage{
+		Magic:        magic,
+		Version:      version,
+		PageSize:     binary.LittleEndian.Uint32(buf[6:10]),
+		RootPageID:   binary.LittleEndian.Uint32(buf[10:14]),
+		FreeListPage: binary.LittleEndian.Uint32(buf[14:18]),
+		KeyCount:     binary.LittleEndian.Uint64(buf[18:26]),
+		PageCount:    binary.LittleEndian.Uint32(buf[26:30]),
+	}, nil
+}
+
+// Node represents a B+Tree node (internal or leaf).
+// Layout:
+// Header (32 bytes):
+// +--------+--------+--------+--------+--------+--------+
+// | Type(1)| KeyCnt(2)| Parent(4)| Next(4)| Prev(4)| ...  |
+// +--------+--------+--------+--------+--------+--------+
+// Body (variable):
+// For leaf: [keyLen(2)|key|valLen(2)|value] ...
+// For internal: [keyLen(2)|key|childPtr(4)] ... [lastChildPtr(4)]
+type Node struct {
+	PageID   uint32
+	PageType uint8
+	KeyCount uint16
+	Parent   uint32
+	Next     uint32 // for leaf nodes: next sibling
+	Prev     uint32 // for leaf nodes: previous sibling
+
+	Keys     [][]byte
+	Values   []*wal.ChunkPosition // for leaf nodes
+	Children []uint32             // for internal nodes
+
+	dirty bool
+}
+
+// IsLeaf returns true if the node is a leaf node.
+func (n *Node) IsLeaf() bool {
+	return n.PageType == PageTypeLeaf
+}
+
+// Serialize serializes the node to bytes.
+func (n *Node) Serialize(pageSize uint32) []byte {
+	buf := make([]byte, pageSize)
+
+	// Header
+	buf[0] = n.PageType
+	binary.LittleEndian.PutUint16(buf[1:3], n.KeyCount)
+	binary.LittleEndian.PutUint32(buf[3:7], n.Parent)
+	binary.LittleEndian.PutUint32(buf[7:11], n.Next)
+	binary.LittleEndian.PutUint32(buf[11:15], n.Prev)
+
+	offset := nodeHeaderSize
+
+	if n.IsLeaf() {
+		// Leaf node: serialize key-value pairs
+		for i := 0; i < int(n.KeyCount); i++ {
+			key := n.Keys[i]
+			// key length
+			binary.LittleEndian.PutUint16(buf[offset:offset+2], uint16(len(key)))
+			offset += 2
+			// key
+			copy(buf[offset:], key)
+			offset += len(key)
+			// value (ChunkPosition)
+			offset += serializeChunkPosition(buf[offset:], n.Values[i])
+		}
+	} else {
+		// Internal node: serialize keys and children
+		for i := 0; i < int(n.KeyCount); i++ {
+			key := n.Keys[i]
+			// key length
+			binary.LittleEndian.PutUint16(buf[offset:offset+2], uint16(len(key)))
+			offset += 2
+			// key
+			copy(buf[offset:], key)
+			offset += len(key)
+			// child pointer
+			binary.LittleEndian.PutUint32(buf[offset:offset+4], n.Children[i])
+			offset += 4
+		}
+		// last child pointer
+		if len(n.Children) > int(n.KeyCount) {
+			binary.LittleEndian.PutUint32(buf[offset:offset+4], n.Children[n.KeyCount])
+		}
+	}
+
+	return buf
+}
+
+// DeserializeNode deserializes bytes to a node.
+func DeserializeNode(pageID uint32, buf []byte) (*Node, error) {
+	if len(buf) < nodeHeaderSize {
+		return nil, ErrInvalidPage
+	}
+
+	n := &Node{
+		PageID:   pageID,
+		PageType: buf[0],
+		KeyCount: binary.LittleEndian.Uint16(buf[1:3]),
+		Parent:   binary.LittleEndian.Uint32(buf[3:7]),
+		Next:     binary.LittleEndian.Uint32(buf[7:11]),
+		Prev:     binary.LittleEndian.Uint32(buf[11:15]),
+	}
+
+	offset := nodeHeaderSize
+
+	if n.IsLeaf() {
+		n.Keys = make([][]byte, n.KeyCount)
+		n.Values = make([]*wal.ChunkPosition, n.KeyCount)
+
+		for i := 0; i < int(n.KeyCount); i++ {
+			// key length
+			keyLen := binary.LittleEndian.Uint16(buf[offset : offset+2])
+			offset += 2
+			// key
+			n.Keys[i] = make([]byte, keyLen)
+			copy(n.Keys[i], buf[offset:offset+int(keyLen)])
+			offset += int(keyLen)
+			// value
+			var pos *wal.ChunkPosition
+			pos, offset = deserializeChunkPosition(buf, offset)
+			n.Values[i] = pos
+		}
+	} else {
+		n.Keys = make([][]byte, n.KeyCount)
+		n.Children = make([]uint32, n.KeyCount+1)
+
+		for i := 0; i < int(n.KeyCount); i++ {
+			// key length
+			keyLen := binary.LittleEndian.Uint16(buf[offset : offset+2])
+			offset += 2
+			// key
+			n.Keys[i] = make([]byte, keyLen)
+			copy(n.Keys[i], buf[offset:offset+int(keyLen)])
+			offset += int(keyLen)
+			// child pointer
+			n.Children[i] = binary.LittleEndian.Uint32(buf[offset : offset+4])
+			offset += 4
+		}
+		// last child pointer
+		n.Children[n.KeyCount] = binary.LittleEndian.Uint32(buf[offset : offset+4])
+	}
+
+	return n, nil
+}
+
+// ChunkPosition serialization size: SegmentId(4) + BlockNumber(4) + ChunkOffset(8) + ChunkSize(4) = 20 bytes
+const chunkPositionSize = 20
+
+func serializeChunkPosition(buf []byte, pos *wal.ChunkPosition) int {
+	if pos == nil {
+		// Write zeros for nil position
+		for i := 0; i < chunkPositionSize; i++ {
+			buf[i] = 0
+		}
+		return chunkPositionSize
+	}
+	binary.LittleEndian.PutUint32(buf[0:4], pos.SegmentId)
+	binary.LittleEndian.PutUint32(buf[4:8], pos.BlockNumber)
+	binary.LittleEndian.PutUint64(buf[8:16], uint64(pos.ChunkOffset))
+	binary.LittleEndian.PutUint32(buf[16:20], pos.ChunkSize)
+	return chunkPositionSize
+}
+
+func deserializeChunkPosition(buf []byte, offset int) (*wal.ChunkPosition, int) {
+	pos := &wal.ChunkPosition{
+		SegmentId:   binary.LittleEndian.Uint32(buf[offset : offset+4]),
+		BlockNumber: binary.LittleEndian.Uint32(buf[offset+4 : offset+8]),
+		ChunkOffset: int64(binary.LittleEndian.Uint64(buf[offset+8 : offset+16])),
+		ChunkSize:   binary.LittleEndian.Uint32(buf[offset+16 : offset+20]),
+	}
+	return pos, offset + chunkPositionSize
+}

--- a/index/index.go
+++ b/index/index.go
@@ -50,7 +50,8 @@ type Indexer interface {
 type IndexerType = byte
 
 const (
-	BTree IndexerType = iota
+	BTree  IndexerType = iota
+	BPTree             // B+Tree disk-based index
 )
 
 // Change the index type as you implement.
@@ -63,6 +64,15 @@ func NewIndexer() Indexer {
 	default:
 		panic("unexpected index type")
 	}
+}
+
+// PersistentIndexer is an interface for indexers that support persistence.
+type PersistentIndexer interface {
+	Indexer
+	// Close closes the indexer and releases resources.
+	Close() error
+	// Sync flushes all dirty data to disk.
+	Sync() error
 }
 
 // IndexIterator represents a generic index iterator interface.

--- a/options.go
+++ b/options.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/rosedblabs/rosedb/v2/index"
 )
 
 // Options specifies the options for opening a database.
@@ -43,6 +45,11 @@ type Options struct {
 	// do not set this shecule too frequently, it will affect the performance.
 	// refer to https://en.wikipedia.org/wiki/Cron
 	AutoMergeCronExpr string
+
+	// IndexType specifies the type of index to use.
+	// Default is BTree (in-memory), which requires rebuilding on startup.
+	// BPTree (disk-based B+Tree) provides persistence and faster startup.
+	IndexType index.IndexerType
 }
 
 // BatchOptions specifies the options for creating a batch.
@@ -83,6 +90,7 @@ var DefaultOptions = Options{
 	BytesPerSync:      0,
 	WatchQueueSize:    0,
 	AutoMergeCronExpr: "",
+	IndexType:         index.BTree, // default to in-memory BTree
 }
 
 var DefaultBatchOptions = BatchOptions{

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Script to run all tests with both BTree and BPTree index types
+# Usage: ./scripts/run_tests_all_indexes.sh [-race] [-v]
+
+set -e
+
+RACE_FLAG=""
+VERBOSE_FLAG=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -race)
+            RACE_FLAG="-race"
+            shift
+            ;;
+        -v)
+            VERBOSE_FLAG="-v"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [-race] [-v]"
+            exit 1
+            ;;
+    esac
+done
+
+OPTIONS_FILE="options.go"
+BACKUP_FILE="options.go.bak"
+
+# Backup original options.go
+cp "$OPTIONS_FILE" "$BACKUP_FILE"
+
+# Function to restore original file
+cleanup() {
+    if [ -f "$BACKUP_FILE" ]; then
+        mv "$BACKUP_FILE" "$OPTIONS_FILE"
+    fi
+}
+
+# Set trap to restore on exit
+trap cleanup EXIT
+
+echo "========================================"
+echo "Running tests with BTree index (default)"
+echo "========================================"
+
+# Set BTree as default
+sed -i.tmp 's/IndexType:.*index\.BPTree/IndexType:         index.BTree/' "$OPTIONS_FILE"
+sed -i.tmp 's/IndexType:.*index\.BTree/IndexType:         index.BTree/' "$OPTIONS_FILE"
+rm -f "$OPTIONS_FILE.tmp"
+
+go clean -testcache
+if go test $RACE_FLAG $VERBOSE_FLAG ./...; then
+    echo ""
+    echo "✅ BTree tests PASSED"
+else
+    echo ""
+    echo "❌ BTree tests FAILED"
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "Running tests with BPTree index"
+echo "========================================"
+
+# Set BPTree as default
+sed -i.tmp 's/IndexType:.*index\.BTree/IndexType:         index.BPTree/' "$OPTIONS_FILE"
+rm -f "$OPTIONS_FILE.tmp"
+
+go clean -testcache
+if go test $RACE_FLAG $VERBOSE_FLAG ./...; then
+    echo ""
+    echo "✅ BPTree tests PASSED"
+else
+    echo ""
+    echo "❌ BPTree tests FAILED"
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "✅ All tests passed for both index types!"
+echo "========================================"


### PR DESCRIPTION
Add a disk-based B+Tree index as an alternative to the in-memory BTree index, with page cache, iterator support, and proper concurrency control.